### PR TITLE
build: add Maven Central publishing configuration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: Publish
+on:
+  workflow_dispatch:
+jobs:
+  publish:
+    name: Release build and publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: 21
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+      - name: Publish to MavenCentral
+        run: ./gradlew publishToMavenCentral --no-configuration-cache
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY_CONTENTS }}

--- a/tpstreams-android-player/build.gradle.kts
+++ b/tpstreams-android-player/build.gradle.kts
@@ -1,12 +1,19 @@
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
     id("maven-publish")
+    id("signing")
+    id("com.vanniktech.maven.publish") version "0.31.0"
 }
 
 android {
-    namespace = "com.tpstreams.player"
+    namespace = "com.tpstreams"
     compileSdk = 35
+    version = "0.0.1"
+    group = "com.tpstreams"
 
     defaultConfig {
         minSdk = 21
@@ -62,6 +69,34 @@ dependencies {
             repositories {
                 mavenLocal()
             }
+        }
+    }
+}
+
+mavenPublishing {
+
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+
+    signAllPublications()
+
+    coordinates(group.toString(), "tpstreams-player", version.toString())
+
+    pom {
+        name.set("TPStreamsAndroidPlayer")
+        description.set("An android sdk for TPStreams Player")
+        url.set("https://github.com/testpress/TPStreamsAndroidPlayer")
+
+        licenses {
+            license {
+                name.set("The Apache License, Version 2.0")
+                url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+            }
+        }
+
+        scm {
+            url.set("https://github.com/testpress/TPStreamsAndroidPlayer")
+            connection.set("scm:git:git://github.com:testpress/TPStreamsAndroidPlayer.git")
+            developerConnection.set("scm:git:ssh://gitgithub.com:testpress/TPStreamsAndroidPlayer.git")
         }
     }
 }

--- a/tpstreams-android-player/build.gradle.kts
+++ b/tpstreams-android-player/build.gradle.kts
@@ -96,7 +96,7 @@ mavenPublishing {
         scm {
             url.set("https://github.com/testpress/TPStreamsAndroidPlayer")
             connection.set("scm:git:git://github.com:testpress/TPStreamsAndroidPlayer.git")
-            developerConnection.set("scm:git:ssh://gitgithub.com:testpress/TPStreamsAndroidPlayer.git")
+            developerConnection.set("scm:git:ssh://github.com:testpress/TPStreamsAndroidPlayer.git")
         }
     }
 }


### PR DESCRIPTION
- Configure Gradle to publish artifacts to Maven Central.
- Set up signing, metadata, and repository credentials.
- Add CI workflow to automate release publishing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced automated publishing workflow for Maven Central, including artifact signing and authentication.
  - Updated build configuration to streamline and standardize publishing to Maven Central, with improved metadata and automated signing.
  - Changed Android library namespace and explicitly set module version and group ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->