### PR TITLE
fix: Remove default selection flags for subtitles in TPStreamsPlayer

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -132,7 +132,6 @@ private constructor(
                                     .setLanguage(language)
                                     .setLabel(name)
                                     .setMimeType(MimeTypes.TEXT_VTT)
-                                    .setSelectionFlags(C.SELECTION_FLAG_DEFAULT)
                                     .build()
                                 
                                 subtitleConfigurations.add(subtitleConfig)
@@ -299,7 +298,6 @@ private constructor(
         if (language == null) {
             parametersBuilder.setPreferredTextLanguage(null)
             parametersBuilder.setSelectUndeterminedTextLanguage(false)
-            parametersBuilder.setDisabledTextTrackSelectionFlags(C.SELECTION_FLAG_DEFAULT)
             Log.d("TPStreamsPlayer", "Disabling text tracks")
         } else {
             parametersBuilder.setPreferredTextLanguage(language)


### PR DESCRIPTION
- Eliminated the use of default selection flags for subtitle configurations and text track selection, for improving subtitle handling logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved subtitle track handling by removing the default selection flag, which may enhance user experience when choosing subtitle options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->