### PR TITLE
refactor: Update mediaId as assetId instead of Uri

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/DownloadActionBottomSheet.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/DownloadActionBottomSheet.kt
@@ -1,7 +1,6 @@
 package com.tpstreams.player
 
 import android.app.Dialog
-import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -27,15 +26,15 @@ class DownloadActionBottomSheet : BottomSheetDialogFragment() {
     }
 
     private var listener: DownloadActionListener? = null
-    private var currentUri: Uri? = null
+    private var currentAssetId: String? = null
     private var downloadState: Int = Download.STATE_COMPLETED
 
     fun setDownloadActionListener(listener: DownloadActionListener) {
         this.listener = listener
     }
 
-    fun setDownloadUri(uri: Uri) {
-        this.currentUri = uri
+    fun setDownloadAssetId(assetId: String) {
+        this.currentAssetId = assetId
     }
 
     fun setDownloadState(state: Int) {

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/DownloadActions.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/DownloadActions.kt
@@ -16,41 +16,39 @@ class DownloadActions(private val view: TPStreamsPlayerView) {
     fun onDownloadSelected() {
         val tpsPlayer = view.getPlayer() ?: return
         val mediaItem = tpsPlayer.currentMediaItem ?: return
-        val uri = mediaItem.localConfiguration?.uri ?: return
+        val assetId = mediaItem.mediaId
         
         val activity = view.getActivity() ?: return
         val downloadTracker = DownloadTracker.getInstance(view.context)
         
-        if (uri != null) {
-            when {
-                downloadTracker.isDownloaded(uri) -> {
-                    view.downloadActionBottomSheet.setDownloadUri(uri)
-                    view.downloadActionBottomSheet.setDownloadState(Download.STATE_COMPLETED)
-                    view.downloadActionBottomSheet.show(activity.supportFragmentManager)
-                }
-                downloadTracker.isDownloading(uri) -> {
-                    view.downloadActionBottomSheet.setDownloadUri(uri)
-                    view.downloadActionBottomSheet.setDownloadState(Download.STATE_DOWNLOADING)
-                    view.downloadActionBottomSheet.show(activity.supportFragmentManager)
-                }
-                downloadTracker.isPaused(uri) -> {
-                    view.downloadActionBottomSheet.setDownloadUri(uri)
-                    view.downloadActionBottomSheet.setDownloadState(Download.STATE_STOPPED)
-                    view.downloadActionBottomSheet.show(activity.supportFragmentManager)
-                }
-                else -> {
-                    view.downloadOptionsBottomSheet.setDownloadSelectionListener(view)
-                    
-                    // Get available resolutions
-                    val availableHeights = tpsPlayer.getAvailableVideoResolutions()
-                    val resolutionStrings = availableHeights.map { "${it}p" }
-                    view.downloadOptionsBottomSheet.setAvailableResolutions(resolutionStrings)
-                    view.downloadOptionsBottomSheet.setMediaItem(mediaItem, tpsPlayer.duration)
-                    view.downloadOptionsBottomSheet.show(activity.supportFragmentManager)
-                    
-                    val trackBitrates = tpsPlayer.getVideoTrackBitrates()
-                    view.downloadOptionsBottomSheet.setTrackBitrates(trackBitrates)
-                }
+        when {
+            downloadTracker.isDownloaded(assetId) -> {
+                view.downloadActionBottomSheet.setDownloadAssetId(assetId)
+                view.downloadActionBottomSheet.setDownloadState(Download.STATE_COMPLETED)
+                view.downloadActionBottomSheet.show(activity.supportFragmentManager)
+            }
+            downloadTracker.isDownloading(assetId) -> {
+                view.downloadActionBottomSheet.setDownloadAssetId(assetId)
+                view.downloadActionBottomSheet.setDownloadState(Download.STATE_DOWNLOADING)
+                view.downloadActionBottomSheet.show(activity.supportFragmentManager)
+            }
+            downloadTracker.isPaused(assetId) -> {
+                view.downloadActionBottomSheet.setDownloadAssetId(assetId)
+                view.downloadActionBottomSheet.setDownloadState(Download.STATE_STOPPED)
+                view.downloadActionBottomSheet.show(activity.supportFragmentManager)
+            }
+            else -> {
+                view.downloadOptionsBottomSheet.setDownloadSelectionListener(view)
+                
+                // Get available resolutions
+                val availableHeights = tpsPlayer.getAvailableVideoResolutions()
+                val resolutionStrings = availableHeights.map { "${it}p" }
+                view.downloadOptionsBottomSheet.setAvailableResolutions(resolutionStrings)
+                view.downloadOptionsBottomSheet.setMediaItem(mediaItem, tpsPlayer.duration)
+                view.downloadOptionsBottomSheet.show(activity.supportFragmentManager)
+                
+                val trackBitrates = tpsPlayer.getVideoTrackBitrates()
+                view.downloadOptionsBottomSheet.setTrackBitrates(trackBitrates)
             }
         }
     }
@@ -85,37 +83,37 @@ class DownloadActions(private val view: TPStreamsPlayerView) {
     fun deleteCurrentDownload() {
         val tpsPlayer = view.getPlayer() ?: return
         val mediaItem = tpsPlayer.currentMediaItem ?: return
-        val uri = mediaItem.localConfiguration?.uri ?: return
+        val assetId = mediaItem.mediaId
         
-        DownloadTracker.getInstance(view.context).removeDownload(uri)
+        DownloadTracker.getInstance(view.context).removeDownload(assetId)
     }
     
     fun pauseCurrentDownload() {
         val tpsPlayer = view.getPlayer() ?: return
         val mediaItem = tpsPlayer.currentMediaItem ?: return
-        val uri = mediaItem.localConfiguration?.uri ?: return
+        val assetId = mediaItem.mediaId
         
-        DownloadTracker.getInstance(view.context).pauseDownload(uri)
+        DownloadTracker.getInstance(view.context).pauseDownload(assetId)
     }
     
     fun resumeCurrentDownload() {
         val tpsPlayer = view.getPlayer() ?: return
         val mediaItem = tpsPlayer.currentMediaItem ?: return
-        val uri = mediaItem.localConfiguration?.uri ?: return
+        val assetId = mediaItem.mediaId
         
-        DownloadTracker.getInstance(view.context).resumeDownload(uri)
+        DownloadTracker.getInstance(view.context).resumeDownload(assetId)
     }
 
     fun getCurrentDownloadStatus(): String {
         val tpsPlayer = view.getPlayer() ?: return "Download"
         val mediaItem = tpsPlayer.currentMediaItem ?: return "Download"
-        val uri = mediaItem.localConfiguration?.uri ?: return "Download"
+        val assetId = mediaItem.mediaId
         
         val downloadTracker = DownloadTracker.getInstance(view.context)
         return when {
-            downloadTracker.isDownloaded(uri) -> "Downloaded"
-            downloadTracker.isDownloading(uri) -> "Downloading"
-            downloadTracker.isPaused(uri) -> "Paused"
+            downloadTracker.isDownloaded(assetId) -> "Downloaded"
+            downloadTracker.isDownloading(assetId) -> "Downloading"
+            downloadTracker.isPaused(assetId) -> "Paused"
             else -> "Download"
         }
     }
@@ -123,13 +121,13 @@ class DownloadActions(private val view: TPStreamsPlayerView) {
     fun getDownloadIcon(): Int {
         val tpsPlayer = view.getPlayer() ?: return R.drawable.ic_download
         val mediaItem = tpsPlayer.currentMediaItem ?: return R.drawable.ic_download
-        val uri = mediaItem.localConfiguration?.uri ?: return R.drawable.ic_download
+        val assetId = mediaItem.mediaId
         
         val downloadTracker = DownloadTracker.getInstance(view.context)
         return when {
-            downloadTracker.isDownloaded(uri) -> R.drawable.ic_download_done
-            downloadTracker.isDownloading(uri) -> R.drawable.ic_download_progress
-            downloadTracker.isPaused(uri) -> R.drawable.ic_download_progress
+            downloadTracker.isDownloaded(assetId) -> R.drawable.ic_download_done
+            downloadTracker.isDownloading(assetId) -> R.drawable.ic_download_progress
+            downloadTracker.isPaused(assetId) -> R.drawable.ic_download_progress
             else -> R.drawable.ic_download
         }
     }

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -45,6 +45,8 @@ private constructor(
     private var subtitleMetadata = mapOf<String, Boolean>()
     
     init {
+        Log.d("TPStreamsPlayer", "Initializing TPStreamsPlayer with assetId: $assetId")
+        
         exoPlayer.addListener(object : Player.Listener {
             @OptIn(UnstableApi::class)
             override fun onTracksChanged(tracks: Tracks) {
@@ -193,16 +195,12 @@ private constructor(
     private fun playFromDownload(assetId: String): Boolean {
         try {
             val downloadTracker = DownloadTracker.getInstance(context)
-            val downloads = downloadTracker.getAllDownloads()
+            val download = downloadTracker.getDownload(assetId)
             
-            val matchingDownload = downloads.firstOrNull { download ->
-                download.request.id.contains(assetId)
-            }
-            
-            if (matchingDownload != null) {
+            if (download != null) {
                 Log.d("TPStreamsPlayer", "Found downloaded content for $assetId, using local version")
 
-                val downloadedMediaItem = DownloadController.buildMediaItemFromDownload(matchingDownload)
+                val downloadedMediaItem = DownloadController.buildMediaItemFromDownload(download)
                 if (downloadedMediaItem == null) {
                     Log.e("TPStreamsPlayer", "Failed to build media item from download for $assetId")
                     return false


### PR DESCRIPTION
- Changed the DownloadActionBottomSheet to accept assetId for download actions.
- Updated DownloadActions to utilize assetId for download state checks and actions.
- Refactored DownloadTracker to manage downloads using assetId instead of Uri, improving consistency and clarity in download management.
- Enhanced methods for checking download status and managing downloads to align with the new assetId approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Download management now uses asset IDs instead of URIs to identify and track downloads across the app.
  - Improved consistency in download controls and status displays by switching to asset ID-based references.
  - Enhanced logging for better debugging during download and playback operations.

- **Bug Fixes**
  - Ensured accurate download status and actions by aligning all download tracking to use asset IDs.

- **New Features**
  - More robust handling of downloads and media items with explicit asset ID assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->