### PR TITLE
feat: Add metadata support for downloads with title and thumbnail

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadItem.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadItem.kt
@@ -1,0 +1,17 @@
+package com.tpstreams.player.download
+
+import androidx.annotation.Keep
+
+/**
+ * Data class representing a downloadable item with metadata
+ */
+@Keep
+data class DownloadItem(
+    val assetId: String,
+    val title: String,
+    val thumbnailUrl: String? = null,
+    val totalBytes: Long = 0,
+    val downloadedBytes: Long = 0,
+    val progressPercentage: Float = 0f,
+    val state: Int = 0
+) 


### PR DESCRIPTION
- Extract title and thumbnail from video API response
- Add MediaMetadata to MediaItem with title and artwork URI
- Store metadata in download requests using JSON format
- Create DownloadItem data class for structured download information
- Update DownloadTracker to handle metadata extraction and create DownloadItems

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new DownloadItem model to provide detailed metadata for downloads, including title, thumbnail, size, progress, and state.
  - Added the ability to retrieve a list of all downloads with their associated metadata.

- **Improvements**
  - Enhanced download tracking and operations to use asset IDs instead of URIs, resulting in more reliable and consistent download management.
  - Embedded media metadata (title and thumbnail) within download requests for richer offline playback experiences.
  - Improved logging for better traceability of downloads and metadata extraction.

- **Bug Fixes**
  - Ensured media items downloaded and played offline have consistent metadata and identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->