### PR TITLE
feat: Add download list in the App

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,11 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".DownloadsActivity"
+            android:exported="false"
+            android:label="Downloads"
+            android:parentActivityName=".MainActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/tpstreams/player/DownloadAdapter.kt
+++ b/app/src/main/java/com/tpstreams/player/DownloadAdapter.kt
@@ -10,7 +10,6 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.tpstreams.player.download.DownloadItem
-import java.text.DecimalFormat
 
 class DownloadAdapter : ListAdapter<DownloadItem, DownloadAdapter.DownloadViewHolder>(DownloadDiffCallback()) {
 
@@ -38,24 +37,14 @@ class DownloadAdapter : ListAdapter<DownloadItem, DownloadAdapter.DownloadViewHo
             val progress = downloadItem.progressPercentage.toInt()
             progressBar.progress = progress
             
-            // Format file sizes
-            val downloadedSize = formatFileSize(downloadItem.downloadedBytes)
-            val totalSize = formatFileSize(downloadItem.totalBytes)
-            progressText.text = "$progress% • $downloadedSize / $totalSize"
+            // Show only percentage
+            progressText.text = "$progress%"
             
             // Set state text
             stateText.text = getStateString(downloadItem.state)
         }
         
-        private fun formatFileSize(bytes: Long): String {
-            val df = DecimalFormat("0.00")
-            return when {
-                bytes < 1024 -> "$bytes B"
-                bytes < 1024 * 1024 -> "${df.format(bytes / 1024.0)} KB"
-                bytes < 1024 * 1024 * 1024 -> "${df.format(bytes / (1024.0 * 1024.0))} MB"
-                else -> "${df.format(bytes / (1024.0 * 1024.0 * 1024.0))} GB"
-            }
-        }
+
         
         private fun getStateString(state: Int): String {
             return when (state) {

--- a/app/src/main/java/com/tpstreams/player/DownloadAdapter.kt
+++ b/app/src/main/java/com/tpstreams/player/DownloadAdapter.kt
@@ -1,0 +1,83 @@
+package com.tpstreams.player
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ProgressBar
+import android.widget.TextView
+import androidx.media3.exoplayer.offline.Download
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.tpstreams.player.download.DownloadItem
+import java.text.DecimalFormat
+
+class DownloadAdapter : ListAdapter<DownloadItem, DownloadAdapter.DownloadViewHolder>(DownloadDiffCallback()) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): DownloadViewHolder {
+        val view = LayoutInflater.from(parent.context).inflate(R.layout.item_download, parent, false)
+        return DownloadViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: DownloadViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class DownloadViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val titleText: TextView = itemView.findViewById(R.id.title_text)
+        private val assetIdText: TextView = itemView.findViewById(R.id.asset_id_text)
+        private val progressBar: ProgressBar = itemView.findViewById(R.id.download_progress)
+        private val progressText: TextView = itemView.findViewById(R.id.progress_text)
+        private val stateText: TextView = itemView.findViewById(R.id.state_text)
+
+        fun bind(downloadItem: DownloadItem) {
+            titleText.text = downloadItem.title
+            assetIdText.text = "Asset ID: ${downloadItem.assetId}"
+            
+            // Set progress
+            val progress = downloadItem.progressPercentage.toInt()
+            progressBar.progress = progress
+            
+            // Format file sizes
+            val downloadedSize = formatFileSize(downloadItem.downloadedBytes)
+            val totalSize = formatFileSize(downloadItem.totalBytes)
+            progressText.text = "$progress% • $downloadedSize / $totalSize"
+            
+            // Set state text
+            stateText.text = getStateString(downloadItem.state)
+        }
+        
+        private fun formatFileSize(bytes: Long): String {
+            val df = DecimalFormat("0.00")
+            return when {
+                bytes < 1024 -> "$bytes B"
+                bytes < 1024 * 1024 -> "${df.format(bytes / 1024.0)} KB"
+                bytes < 1024 * 1024 * 1024 -> "${df.format(bytes / (1024.0 * 1024.0))} MB"
+                else -> "${df.format(bytes / (1024.0 * 1024.0 * 1024.0))} GB"
+            }
+        }
+        
+        private fun getStateString(state: Int): String {
+            return when (state) {
+                Download.STATE_COMPLETED -> "COMPLETED"
+                Download.STATE_DOWNLOADING -> "DOWNLOADING"
+                Download.STATE_FAILED -> "FAILED"
+                Download.STATE_QUEUED -> "QUEUED"
+                Download.STATE_REMOVING -> "REMOVING"
+                Download.STATE_RESTARTING -> "RESTARTING"
+                Download.STATE_STOPPED -> "PAUSED"
+                else -> "UNKNOWN"
+            }
+        }
+    }
+}
+
+class DownloadDiffCallback : DiffUtil.ItemCallback<DownloadItem>() {
+    override fun areItemsTheSame(oldItem: DownloadItem, newItem: DownloadItem): Boolean {
+        return oldItem.assetId == newItem.assetId
+    }
+
+    override fun areContentsTheSame(oldItem: DownloadItem, newItem: DownloadItem): Boolean {
+        return oldItem == newItem
+    }
+} 

--- a/app/src/main/java/com/tpstreams/player/DownloadViewModel.kt
+++ b/app/src/main/java/com/tpstreams/player/DownloadViewModel.kt
@@ -1,0 +1,55 @@
+package com.tpstreams.player
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.media3.common.util.UnstableApi
+import com.tpstreams.player.download.DownloadItem
+import com.tpstreams.player.download.DownloadTracker
+
+@UnstableApi
+class DownloadViewModel(application: Application) : AndroidViewModel(application) {
+    
+    private val _downloads = MutableLiveData<List<DownloadItem>>()
+    val downloads: LiveData<List<DownloadItem>> = _downloads
+    
+    private val _isLoading = MutableLiveData<Boolean>()
+    val isLoading: LiveData<Boolean> = _isLoading
+    
+    private val downloadTracker = DownloadTracker.getInstance(application)
+    private val downloadListener = object : DownloadTracker.Listener {
+        override fun onDownloadsChanged() {
+            loadDownloads()
+        }
+    }
+    
+    init {
+        downloadTracker.addListener(downloadListener)
+        loadDownloads()
+    }
+    
+    fun loadDownloads() {
+        _isLoading.value = true
+        val downloadItems = downloadTracker.getAllDownloadItems()
+        _downloads.value = downloadItems
+        _isLoading.value = false
+    }
+    
+    fun pauseDownload(assetId: String) {
+        downloadTracker.pauseDownload(assetId)
+    }
+    
+    fun resumeDownload(assetId: String) {
+        downloadTracker.resumeDownload(assetId)
+    }
+    
+    fun removeDownload(assetId: String) {
+        downloadTracker.removeDownload(assetId)
+    }
+    
+    override fun onCleared() {
+        super.onCleared()
+        downloadTracker.removeListener(downloadListener)
+    }
+} 

--- a/app/src/main/java/com/tpstreams/player/DownloadsActivity.kt
+++ b/app/src/main/java/com/tpstreams/player/DownloadsActivity.kt
@@ -1,0 +1,130 @@
+package com.tpstreams.player
+
+import android.os.Bundle
+import android.view.MenuItem
+import android.view.View
+import android.widget.PopupMenu
+import androidx.activity.viewModels
+import androidx.annotation.OptIn
+import androidx.appcompat.app.AppCompatActivity
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.offline.Download
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.tpstreams.player.databinding.ActivityDownloadsBinding
+import com.tpstreams.player.download.DownloadItem
+
+@OptIn(UnstableApi::class)
+class DownloadsActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityDownloadsBinding
+    private val viewModel: DownloadViewModel by viewModels()
+    private lateinit var adapter: DownloadAdapter
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityDownloadsBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        // Setup toolbar
+        setSupportActionBar(binding.toolbar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+        // Setup RecyclerView
+        adapter = DownloadAdapter()
+        binding.downloadsRecyclerView.adapter = adapter
+        binding.downloadsRecyclerView.layoutManager = LinearLayoutManager(this)
+
+        // Setup item click listener
+        adapter.registerAdapterDataObserver(object : androidx.recyclerview.widget.RecyclerView.AdapterDataObserver() {
+            override fun onChanged() {
+                checkEmptyState()
+            }
+        })
+
+        // Observe downloads
+        viewModel.downloads.observe(this) { downloads ->
+            adapter.submitList(downloads)
+            checkEmptyState()
+        }
+
+        // Observe loading state
+        viewModel.isLoading.observe(this) { isLoading ->
+            binding.progressBar.visibility = if (isLoading) View.VISIBLE else View.GONE
+        }
+
+        // Setup item click listener with popup menu
+        setupItemClickListener()
+    }
+
+    private fun setupItemClickListener() {
+        binding.downloadsRecyclerView.addOnItemTouchListener(
+            RecyclerItemClickListener(this, binding.downloadsRecyclerView,
+                object : RecyclerItemClickListener.OnItemClickListener {
+                    override fun onItemClick(view: View, position: Int) {
+                        val downloadItem = adapter.currentList[position]
+                        showPopupMenu(view, downloadItem)
+                    }
+
+                    override fun onLongItemClick(view: View, position: Int) {
+                        // Not needed for now
+                    }
+                })
+        )
+    }
+
+    private fun showPopupMenu(view: View, downloadItem: DownloadItem) {
+        val popupMenu = PopupMenu(this, view)
+        
+        when (downloadItem.state) {
+            Download.STATE_COMPLETED -> {
+                popupMenu.menu.add(getString(R.string.delete_download_title))
+            }
+            Download.STATE_DOWNLOADING -> {
+                popupMenu.menu.add(getString(R.string.pause_download))
+                popupMenu.menu.add(getString(R.string.cancel_download))
+            }
+            Download.STATE_STOPPED -> {
+                popupMenu.menu.add(getString(R.string.resume_download))
+                popupMenu.menu.add(getString(R.string.cancel_download))
+            }
+            else -> {
+                popupMenu.menu.add(getString(R.string.cancel_download))
+            }
+        }
+
+        popupMenu.setOnMenuItemClickListener { menuItem ->
+            when (menuItem.title) {
+                getString(R.string.delete_download_title), getString(R.string.cancel_download) -> {
+                    viewModel.removeDownload(downloadItem.assetId)
+                }
+                getString(R.string.pause_download) -> {
+                    viewModel.pauseDownload(downloadItem.assetId)
+                }
+                getString(R.string.resume_download) -> {
+                    viewModel.resumeDownload(downloadItem.assetId)
+                }
+            }
+            true
+        }
+
+        popupMenu.show()
+    }
+
+    private fun checkEmptyState() {
+        if (adapter.itemCount == 0) {
+            binding.emptyView.visibility = View.VISIBLE
+            binding.downloadsRecyclerView.visibility = View.GONE
+        } else {
+            binding.emptyView.visibility = View.GONE
+            binding.downloadsRecyclerView.visibility = View.VISIBLE
+        }
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) {
+            finish()
+            return true
+        }
+        return super.onOptionsItemSelected(item)
+    }
+} 

--- a/app/src/main/java/com/tpstreams/player/MainActivity.kt
+++ b/app/src/main/java/com/tpstreams/player/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.tpstreams.player
 
+import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.viewModels
@@ -22,8 +23,14 @@ class MainActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         // Initialize SDK once
-        TPStreamsPlayer.init("6332n7")
+        TPStreamsPlayer.init("9q94nm")
 
         binding.playerView.player = viewModel.player
+        
+        // Set up downloads button
+        binding.downloadsButton.setOnClickListener {
+            val intent = Intent(this, DownloadsActivity::class.java)
+            startActivity(intent)
+        }
     }
 }

--- a/app/src/main/java/com/tpstreams/player/PlayerUIViewModel.kt
+++ b/app/src/main/java/com/tpstreams/player/PlayerUIViewModel.kt
@@ -12,8 +12,8 @@ class PlayerUIViewModel(application: Application) : AndroidViewModel(application
     val player: TPStreamsPlayer by lazy {
         TPStreamsPlayer.create(
             context = application.applicationContext,
-            assetId = "8rEx9apZHFF",
-            accessToken = "19aa0055-d965-4654-8fce-b804e70a46b0",
+            assetId = "BEArYFdaFbt",
+            accessToken = "e6a1b485-daad-42eb-8cf2-6b6e51631092",
             shouldAutoPlay = false
         )
     }

--- a/app/src/main/java/com/tpstreams/player/RecyclerItemClickListener.kt
+++ b/app/src/main/java/com/tpstreams/player/RecyclerItemClickListener.kt
@@ -1,0 +1,49 @@
+package com.tpstreams.player
+
+import android.content.Context
+import android.view.GestureDetector
+import android.view.MotionEvent
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+
+class RecyclerItemClickListener(
+    context: Context,
+    recyclerView: RecyclerView,
+    private val listener: OnItemClickListener?
+) : RecyclerView.OnItemTouchListener {
+
+    interface OnItemClickListener {
+        fun onItemClick(view: View, position: Int)
+        fun onLongItemClick(view: View, position: Int)
+    }
+
+    private val gestureDetector: GestureDetector
+
+    init {
+        gestureDetector = GestureDetector(context, object : GestureDetector.SimpleOnGestureListener() {
+            override fun onSingleTapUp(e: MotionEvent): Boolean {
+                return true
+            }
+
+            override fun onLongPress(e: MotionEvent) {
+                val childView = recyclerView.findChildViewUnder(e.x, e.y)
+                if (childView != null && listener != null) {
+                    listener.onLongItemClick(childView, recyclerView.getChildAdapterPosition(childView))
+                }
+            }
+        })
+    }
+
+    override fun onInterceptTouchEvent(view: RecyclerView, e: MotionEvent): Boolean {
+        val childView = view.findChildViewUnder(e.x, e.y)
+        if (childView != null && listener != null && gestureDetector.onTouchEvent(e)) {
+            listener.onItemClick(childView, view.getChildAdapterPosition(childView))
+            return true
+        }
+        return false
+    }
+
+    override fun onTouchEvent(view: RecyclerView, motionEvent: MotionEvent) {}
+
+    override fun onRequestDisallowInterceptTouchEvent(disallowIntercept: Boolean) {}
+} 

--- a/app/src/main/res/layout/activity_downloads.xml
+++ b/app/src/main/res/layout/activity_downloads.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".DownloadsActivity">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        android:elevation="4dp"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+        app:layout_constraintTop_toTopOf="parent"
+        app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+        app:title="@string/downloads_title" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/downloads_recycler_view"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:clipToPadding="false"
+        android:padding="8dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolbar" />
+
+    <TextView
+        android:id="@+id/empty_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/no_downloads_available"
+        android:textSize="18sp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolbar" />
+
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolbar" />
+
+</androidx.constraintlayout.widget.ConstraintLayout> 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -16,4 +16,14 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
+    <Button
+        android:id="@+id/downloads_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/view_downloads"
+        android:layout_marginTop="16dp"
+        app:layout_constraintTop_toBottomOf="@id/player_view"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout> 

--- a/app/src/main/res/layout/item_download.xml
+++ b/app/src/main/res/layout/item_download.xml
@@ -54,7 +54,7 @@
             android:textSize="14sp"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/download_progress"
-            tools:text="65% • 120MB / 200MB" />
+            tools:text="65%" />
 
         <TextView
             android:id="@+id/state_text"

--- a/app/src/main/res/layout/item_download.xml
+++ b/app/src/main/res/layout/item_download.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="8dp"
+    app:cardCornerRadius="8dp"
+    app:cardElevation="4dp">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp">
+
+        <TextView
+            android:id="@+id/title_text"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="Video Title" />
+
+        <TextView
+            android:id="@+id/asset_id_text"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textSize="12sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/title_text"
+            tools:text="Asset ID: abc123" />
+
+        <ProgressBar
+            android:id="@+id/download_progress"
+            style="?android:attr/progressBarStyleHorizontal"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/asset_id_text"
+            tools:progress="65" />
+
+        <TextView
+            android:id="@+id/progress_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textSize="14sp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/download_progress"
+            tools:text="65% • 120MB / 200MB" />
+
+        <TextView
+            android:id="@+id/state_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/download_progress"
+            tools:text="COMPLETED" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.cardview.widget.CardView> 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,22 @@
 <resources>
     <string name="app_name">TPStreamsAndroidPlayer</string>
+    
+    <!-- Downloads Screen -->
+    <string name="downloads_title">Downloads</string>
+    <string name="no_downloads_available">No downloads available</string>
+    <string name="view_downloads">View Downloads</string>
+    
+    <!-- Download Actions -->
+    <string name="delete_download_title">Delete Download</string>
+    <string name="delete_download_message">Do you want to delete this download?</string>
+    <string name="downloading_title">Downloading</string>
+    <string name="downloading_message">Your download is in progress</string>
+    <string name="pause_download">Pause Download</string>
+    <string name="resume_download">Resume Download</string>
+    <string name="cancel_download">Cancel Download</string>
+    <string name="download_button">Download</string>
+    <string name="select_download_quality">Select Download Quality</string>
+    <string name="download_size">Size: %1$s</string>
+    <string name="download_status_title">Download Status</string>
+    <string name="download_status_message">Manage your download</string>
 </resources>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a Downloads screen for viewing and managing media downloads.
  - Added a button on the main screen to access the Downloads section.
  - Enabled users to pause, resume, or delete downloads directly from the Downloads screen.
  - Displayed download progress, status, and asset details for each item in a user-friendly list.

- **User Interface**
  - Added new layouts for the Downloads screen and individual download items.
  - Included visual indicators for loading state and empty list messages.

- **Localization**
  - Added new string resources for download-related actions and messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->