### PR TITLE
fix: Replace MaterialButton with AppCompatButton for theme compatibility

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/DownloadActionBottomSheet.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/DownloadActionBottomSheet.kt
@@ -12,7 +12,6 @@ import androidx.fragment.app.FragmentManager
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
-import com.google.android.material.button.MaterialButton
 import com.tpstreams.player.download.DownloadTracker
 import androidx.media3.exoplayer.offline.Download
 import android.widget.ImageView

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/DownloadOptionsBottomSheet.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/DownloadOptionsBottomSheet.kt
@@ -17,7 +17,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
-import com.google.android.material.button.MaterialButton
+import androidx.appcompat.widget.AppCompatButton
 import kotlin.math.roundToInt
 
 class DownloadOptionsBottomSheet : BottomSheetDialogFragment() {
@@ -31,7 +31,7 @@ class DownloadOptionsBottomSheet : BottomSheetDialogFragment() {
     private lateinit var adapter: DownloadResolutionAdapter
     private var selectedResolution: String? = null
     private var downloadSizeText: TextView? = null
-    private var downloadButton: MaterialButton? = null
+    private var downloadButton: AppCompatButton? = null
     private var mediaItem: MediaItem? = null
     private var videoDurationMs: Long = 0
     private var trackBitrates = mutableMapOf<String, Int>()

--- a/tpstreams-android-player/src/main/res/layout/layout_download_options_bottom_sheet.xml
+++ b/tpstreams-android-player/src/main/res/layout/layout_download_options_bottom_sheet.xml
@@ -37,7 +37,7 @@
         android:overScrollMode="never" />
 
     <!-- Download button -->
-    <com.google.android.material.button.MaterialButton
+    <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/download_button"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"


### PR DESCRIPTION
- Updated layout to use AppCompatButton to prevent crashes in non-Material themed apps (e.g., React Native)
- Updated Kotlin code to reference AppCompatButton
- Removed reference of MaterialButton


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the download button in the download options bottom sheet to use a different button style for improved consistency.
- **Style**
  - Adjusted layout to reflect the updated button style.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->