### PR TITLE
fix: Use request ID to correctly remove cached download files

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadTracker.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadTracker.kt
@@ -174,20 +174,9 @@ class DownloadTracker private constructor(private val context: Context) {
         DownloadController.removeDownload(context, download.request.id)
         
         try {
-            DownloadController.downloadCache.removeResource(download.request.uri.toString())
+            DownloadController.downloadCache.removeResource(download.request.id)
             Log.d(TAG, "Cache resource removed for: ${download.request.id}")
-            
-            val downloadDirectory = File(context.getExternalFilesDir(null), DownloadController.DOWNLOAD_CONTENT_DIRECTORY)
-            val downloadFiles = downloadDirectory.listFiles { file -> 
-                file.name.contains(download.request.id.replace("/", "_")) 
-            }
-            
-            downloadFiles?.forEach { file ->
-                if (file.exists()) {
-                    val deleted = file.delete()
-                    Log.d(TAG, "Deleting file ${file.absolutePath}: ${if (deleted) "success" else "failed"}")
-                }
-            }
+
         } catch (e: Exception) {
             Log.e(TAG, "Error removing resources: ${e.message}", e)
         }

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadTracker.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadTracker.kt
@@ -176,7 +176,6 @@ class DownloadTracker private constructor(private val context: Context) {
         try {
             DownloadController.downloadCache.removeResource(download.request.id)
             Log.d(TAG, "Cache resource removed for: ${download.request.id}")
-
         } catch (e: Exception) {
             Log.e(TAG, "Error removing resources: ${e.message}", e)
         }


### PR DESCRIPTION
- Previously, downloaded files were not deleted properly because the cache removal used the URI instead of the request ID.
- This fix uses the correct request ID to ensure all related cache resources are properly removed during deletion.