### PR TITLE
feat: Enforce TPStreamsSDK as sole SDK init entry

### DIFF
--- a/app/src/main/java/com/tpstreams/player/MainActivity.kt
+++ b/app/src/main/java/com/tpstreams/player/MainActivity.kt
@@ -22,7 +22,7 @@ class MainActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         // Initialize SDK once
-        TPStreamsPlayer.init("6332n7")
+        TPStreamsSDK.init("6332n7")
 
         binding.playerView.player = viewModel.player
     }

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -445,7 +445,7 @@ private constructor(
     companion object {
         private var organizationId: String? = null
 
-        fun init(orgId: String) {
+        internal fun init(orgId: String) {
             organizationId = orgId
         }
 

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsSDK.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsSDK.kt
@@ -1,0 +1,9 @@
+package com.tpstreams.player
+
+object TPStreamsSDK {
+
+    @JvmStatic
+    fun init(orgId: String) {
+        TPStreamsPlayer.init(orgId)
+    }
+} 


### PR DESCRIPTION
- TPStreamsSDK now acts as the only publicly accessible API for SDK initialization.
- Made TPStreamsPlayer.init(orgId) internal to restrict direct usage from outside the SDK module.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new static entry point for SDK initialization, making it easier to initialize the player SDK.
- **Refactor**
	- Updated the initialization process in the app to use the new SDK entry point.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->