### PR TITLE
fix: Hide ExoPlayer overflow button

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerControlView.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerControlView.kt
@@ -40,6 +40,7 @@ class TPStreamsPlayerControlView @JvmOverloads constructor(
         
         // Hide default settings button
         findViewById<ImageButton>(androidx.media3.ui.R.id.exo_settings)?.visibility = View.GONE
+        findViewById<ImageButton>(androidx.media3.ui.R.id.exo_overflow_show)?.visibility = View.GONE
     }
 
     /**


### PR DESCRIPTION
- Set exo_overflow_show visibility to GONE.  
- Avoids space reservation in control layout.  
- Fixes misalignment when used via React Native.