### PR TITLE
fix: Prevent time format shortening in React Native layout

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/ui/AutoSizeTimeTextView.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/ui/AutoSizeTimeTextView.kt
@@ -1,0 +1,72 @@
+package com.tpstreams.player.ui
+
+import android.content.Context
+import android.text.TextUtils
+import android.util.AttributeSet
+import android.util.TypedValue
+import androidx.appcompat.widget.AppCompatTextView
+
+class AutoSizeTimeTextView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : AppCompatTextView(context, attrs, defStyleAttr) {
+
+    private val minTextSize = 10f
+    private val maxTextSize = 24f
+    private var initialTextSize = textSize
+    
+    private val sampleTimePatterns = arrayOf(
+        "0:00", "00:00", "0:00:00", "00:00:00", "99:59:59"
+    )
+    
+    init {
+        maxLines = 1
+        ellipsize = null
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        val mode = MeasureSpec.getMode(widthMeasureSpec)
+        
+        if (mode == MeasureSpec.EXACTLY) {
+            val exactWidth = MeasureSpec.getSize(widthMeasureSpec)
+            val textWidth = paint.measureText(text.toString())
+            
+            if (textWidth > exactWidth) {
+                val scaleFactor = exactWidth / textWidth
+                val newTextSize = Math.max(minTextSize, Math.min(textSize * scaleFactor, maxTextSize))
+                setTextSize(TypedValue.COMPLEX_UNIT_PX, newTextSize)
+            } else {
+                setTextSize(TypedValue.COMPLEX_UNIT_PX, initialTextSize)
+            }
+            
+            super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+            return
+        }
+        
+        if (mode == MeasureSpec.AT_MOST || mode == MeasureSpec.UNSPECIFIED) {
+            var maxWidth = paint.measureText(text?.toString() ?: "")
+            
+            if (text?.toString()?.matches(Regex(".*[0-9]:[0-9].*")) == true) {
+                for (pattern in sampleTimePatterns) {
+                    val patternWidth = paint.measureText(pattern)
+                    maxWidth = Math.max(maxWidth, patternWidth)
+                }
+            }
+            
+            val desiredWidth = maxWidth.toInt() + paddingLeft + paddingRight
+            
+            val newWidthMeasureSpec = MeasureSpec.makeMeasureSpec(desiredWidth, MeasureSpec.EXACTLY)
+            
+            super.onMeasure(newWidthMeasureSpec, heightMeasureSpec)
+            return
+        }
+        
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+    }
+
+    override fun setText(text: CharSequence?, type: BufferType?) {
+        super.setText(text, type)
+        requestLayout()
+    }
+} 

--- a/tpstreams-android-player/src/main/res/layout/tpstreams_player_control_view.xml
+++ b/tpstreams-android-player/src/main/res/layout/tpstreams_player_control_view.xml
@@ -35,22 +35,37 @@
         <LinearLayout android:id="@id/exo_time"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:paddingStart="@dimen/exo_styled_bottom_bar_time_padding"
-            android:paddingEnd="@dimen/exo_styled_bottom_bar_time_padding"
-            android:paddingLeft="@dimen/exo_styled_bottom_bar_time_padding"
-            android:paddingRight="@dimen/exo_styled_bottom_bar_time_padding"
+            android:layout_marginStart="4dp"
+            android:layout_marginLeft="4dp"
+            android:paddingEnd="4dp"
+            android:paddingRight="4dp"
             android:layout_gravity="center_vertical|start"
-            android:layoutDirection="ltr">
+            android:orientation="horizontal">
 
-            <TextView android:id="@id/exo_position"
-                style="@style/ExoStyledControls.TimeText.Position"/>
+            <LinearLayout android:id="@id/exo_time"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:layoutDirection="ltr"
+                android:orientation="horizontal"
+                android:gravity="center_vertical">
 
-            <TextView
-                style="@style/ExoStyledControls.TimeText.Separator"/>
+                <com.tpstreams.player.ui.AutoSizeTimeTextView android:id="@id/exo_position"
+                    style="@style/ExoStyledControls.TimeText.Position"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"/>
 
-            <TextView android:id="@id/exo_duration"
-                style="@style/ExoStyledControls.TimeText.Duration"/>
+                <TextView
+                    style="@style/ExoStyledControls.TimeText.Separator"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"/>
 
+                <com.tpstreams.player.ui.AutoSizeTimeTextView android:id="@id/exo_duration"
+                    style="@style/ExoStyledControls.TimeText.Duration"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"/>
+
+            </LinearLayout>
         </LinearLayout>
 
         <LinearLayout android:id="@id/exo_basic_controls"

--- a/tpstreams-android-player/src/main/res/values-sw600dp/dimens.xml
+++ b/tpstreams-android-player/src/main/res/values-sw600dp/dimens.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="timer_text_padding">3dp</dimen>
+    <dimen name="timer_text_size">16sp</dimen>
+</resources> 

--- a/tpstreams-android-player/src/main/res/values-sw720dp/dimens.xml
+++ b/tpstreams-android-player/src/main/res/values-sw720dp/dimens.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="timer_text_padding">4dp</dimen>
+    <dimen name="timer_text_size">18sp</dimen>
+</resources> 

--- a/tpstreams-android-player/src/main/res/values/dimens.xml
+++ b/tpstreams-android-player/src/main/res/values/dimens.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="timer_text_padding">2dp</dimen>
+    <dimen name="timer_text_size">13sp</dimen>
+</resources> 

--- a/tpstreams-android-player/src/main/res/values/styles.xml
+++ b/tpstreams-android-player/src/main/res/values/styles.xml
@@ -23,4 +23,32 @@
         <item name="cornerSizeBottomRight">0dp</item>
         <item name="cornerSizeBottomLeft">0dp</item>
     </style>
+
+    <style name="ExoStyledControls.TimeText.Base">
+        <item name="android:textSize">@dimen/timer_text_size</item>
+        <item name="android:textStyle">normal</item>
+        <item name="android:textColor">@color/exo_white</item>
+        <item name="android:fontFamily">sans-serif</item>
+        <item name="android:maxLines">1</item>
+        <item name="android:ellipsize">none</item>
+    </style>
+
+    <style name="ExoStyledControls.TimeText.Position" parent="ExoStyledControls.TimeText.Base">
+        <item name="android:gravity">end|center_vertical</item>
+        <item name="android:paddingEnd">@dimen/timer_text_padding</item>
+        <item name="android:paddingRight">@dimen/timer_text_padding</item>
+    </style>
+
+    <style name="ExoStyledControls.TimeText.Separator" parent="ExoStyledControls.TimeText.Base">
+        <item name="android:text">@string/timer_divider</item>
+        <item name="android:gravity">center</item>
+        <item name="android:paddingLeft">1dp</item>
+        <item name="android:paddingRight">1dp</item>
+    </style>
+
+    <style name="ExoStyledControls.TimeText.Duration" parent="ExoStyledControls.TimeText.Base">
+        <item name="android:gravity">start|center_vertical</item>
+        <item name="android:paddingStart">@dimen/timer_text_padding</item>
+        <item name="android:paddingLeft">@dimen/timer_text_padding</item>
+    </style>
 </resources> 


### PR DESCRIPTION
- Introduced AutoSizeTimeTextView to dynamically calculate required width for full time patterns (up to 99:59:59).
- Adjusts text size when constrained rather than allowing fallback to a shorter time format.
- Ensures consistent time display by overriding `onMeasure()` and managing width requirements explicitly.