### PR TITLE
fix: Ensure startAt seeks correctly on stream playback

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -222,10 +222,10 @@ private constructor(
     }
 
     private fun seekToStartAt() {
-        if (playbackState == Player.STATE_READY && !hasSeekedToStartAt) {
+        if (playbackState == Player.STATE_READY && !hasSeekedToStartAt && startAt > 0) {
             val duration = exoPlayer.duration
             if (duration > 0 && duration != C.TIME_UNSET) {
-                val seekPosition = minOf(startAt * 1000, duration - 1000)
+                val seekPosition = minOf(startAt * 1000, maxOf(0, duration - 1000))
                 seekTo(seekPosition)
                 hasSeekedToStartAt = true
             }


### PR DESCRIPTION
- Seek only after player reaches STATE_READY to avoid timing issues
- Add a flag to ensure seeking happens only once per session
- Prevent seeking beyond available duration for safe playback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback behavior when starting from a specified position, ensuring smoother and more reliable seeking at the beginning of playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->