### PR TITLE
fix: state undefined before download starts

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadController.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadController.kt
@@ -159,6 +159,7 @@ object DownloadController {
     
     fun getStateString(state: Int): String {
         return when (state) {
+            Download.STATE_QUEUED -> "Queued"
             Download.STATE_DOWNLOADING -> "Downloading"
             Download.STATE_COMPLETED -> "Completed"
             Download.STATE_FAILED -> "Failed"


### PR DESCRIPTION
- Updated the getStateString method in DownloadController to include a new state "Queued" .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Queued" state to more clearly indicate when a download is waiting to start.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->