### PR TITLE
feat: Add metadata support to download

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/DownloadActions.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/DownloadActions.kt
@@ -8,6 +8,7 @@ import androidx.media3.exoplayer.offline.Download
 import com.tpstreams.player.download.DownloadPermissionHandler
 import com.tpstreams.player.download.DownloadClient
 import androidx.media3.common.C
+import com.tpstreams.player.download.DownloadConstants
 
 class DownloadActions(private val view: TPStreamsPlayerView) {
     companion object {
@@ -74,7 +75,10 @@ class DownloadActions(private val view: TPStreamsPlayerView) {
         val downloadClient = DownloadClient.getInstance(view.context)
         val tpsPlayer = view.getPlayer() ?: return
         val assetId = tpsPlayer.assetId
-        
+        val metadata = tpsPlayer?.downloadMetadata ?: mapOf(
+            DownloadConstants.KEY_DOWNLOAD_DATE to System.currentTimeMillis().toString()
+        )
+
         tpsPlayer.isTokenValid(assetId) { isValid ->
             if (!isValid) {
                 tpsPlayer.getNewToken(assetId) { token ->
@@ -84,13 +88,13 @@ class DownloadActions(private val view: TPStreamsPlayerView) {
                     }
     
                     val updatedMediaItem = mediaItem.updateMediaItemDrmConfig(token)
-                    downloadClient.startDownload(updatedMediaItem, resolution)
+                    downloadClient.startDownload(updatedMediaItem, resolution, metadata)
                     showToast("Starting download for $resolution", false)
                 }
                 return@isTokenValid
             }
     
-            downloadClient.startDownload(mediaItem, resolution)
+            downloadClient.startDownload(mediaItem, resolution, metadata)
             showToast("Starting download for $resolution", false)
         }
     }

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/DownloadActions.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/DownloadActions.kt
@@ -75,9 +75,7 @@ class DownloadActions(private val view: TPStreamsPlayerView) {
         val downloadClient = DownloadClient.getInstance(view.context)
         val tpsPlayer = view.getPlayer() ?: return
         val assetId = tpsPlayer.assetId
-        val metadata = tpsPlayer?.downloadMetadata ?: mapOf(
-            DownloadConstants.KEY_DOWNLOAD_DATE to System.currentTimeMillis().toString()
-        )
+        val metadata = tpsPlayer.downloadMetadata ?: emptyMap()
 
         tpsPlayer.isTokenValid(assetId) { isValid ->
             if (!isValid) {

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -41,7 +41,8 @@ private constructor(
     private val shouldAutoPlay: Boolean = true,
     private val startAt: Long = 0,
     val enableDownload: Boolean = false,
-    private val showDefaultCaptions: Boolean = false
+    private val showDefaultCaptions: Boolean = false,
+    val downloadMetadata: Map<String, String>? = null
 ) : Player by exoPlayer {
 
     interface Listener {
@@ -581,10 +582,21 @@ private constructor(
             shouldAutoPlay: Boolean = true,
             startAt: Long = 0,
             enableDownload: Boolean = false,
-            showDefaultCaptions: Boolean = false
+            showDefaultCaptions: Boolean = false,
+            downloadMetadata: Map<String, String>? = null
         ): TPStreamsPlayer {
             val (exo, trackSelector) = createExoPlayer(context)
-            return TPStreamsPlayer(context, exo, trackSelector, assetId, accessToken, shouldAutoPlay, startAt, enableDownload, showDefaultCaptions)
+            return TPStreamsPlayer(
+                context,
+                exo,
+                trackSelector,
+                assetId,
+                accessToken,
+                shouldAutoPlay,
+                startAt,
+                enableDownload,
+                showDefaultCaptions,
+                downloadMetadata)
         }
     }
 }

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadClient.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadClient.kt
@@ -58,11 +58,8 @@ class DownloadClient private constructor(private val context: Context) {
                     .takeIf { it?.isNotEmpty() == true }
 
                 val metadataObj = json.optJSONObject(DownloadConstants.KEY_CUSTOM_METADATA)
-                if (metadataObj != null) {
-                    metadataObj.keys().forEach { key ->
-                        customMetadata[key] = metadataObj.optString(key, "")
-                    }
-                }
+                val map = metadataObj.keys().asSequence().associateWith { metadataObj.getString(it) }
+                customMetadata.putAll(map)
             }
         } catch (e: Exception) {
             Log.e(TAG, "Error extracting metadata from download: ${e.message}")

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadConstants.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadConstants.kt
@@ -1,0 +1,9 @@
+package com.tpstreams.player.download
+
+object DownloadConstants {
+    const val KEY_CUSTOM_METADATA = "customMetadata"
+    const val KEY_TITLE = "title"
+    const val KEY_THUMBNAIL_URL = "thumbnailUrl"
+    const val KEY_DOWNLOAD_DATE = "downloadDate"
+    const val KEY_CATEGORY = "category"
+} 

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadConstants.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadConstants.kt
@@ -4,6 +4,4 @@ object DownloadConstants {
     const val KEY_CUSTOM_METADATA = "customMetadata"
     const val KEY_TITLE = "title"
     const val KEY_THUMBNAIL_URL = "thumbnailUrl"
-    const val KEY_DOWNLOAD_DATE = "downloadDate"
-    const val KEY_CATEGORY = "category"
 } 

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadController.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadController.kt
@@ -206,7 +206,7 @@ object DownloadController {
         return DefaultDataSource.Factory(context, httpDataSourceFactory)
     }
     
-    fun startDownload(context: Context, mediaItem: MediaItem, resolution: String) {
+    fun startDownload(context: Context, mediaItem: MediaItem, resolution: String, metadata: Map<String, String>) {
         Log.d(TAG, "Preparing download for: ${mediaItem.mediaId}")
         val title = mediaItem.mediaMetadata.title?.toString() ?: "Undefined"
         val thumbnailUrl = mediaItem.mediaMetadata.artworkUri?.toString() ?: ""
@@ -227,8 +227,17 @@ object DownloadController {
                     val baseRequest = helper.getDownloadRequest(mediaItem.mediaId.toByteArray())
                     
                     val metadataJson = JSONObject().apply {
-                        put("title", title)
-                        put("thumbnailUrl", thumbnailUrl)
+                        put(DownloadConstants.KEY_TITLE, title)
+                        put(DownloadConstants.KEY_THUMBNAIL_URL, thumbnailUrl)
+
+                        // Add custom metadata if provided
+                        metadata?.let { customMetadata ->
+                            val customMetadataObj = JSONObject()
+                            customMetadata.forEach { (key, value) ->
+                                customMetadataObj.put(key, value)
+                            }
+                            put(DownloadConstants.KEY_CUSTOM_METADATA, customMetadataObj)
+                        }
                     }.toString()
 
                     val request = DownloadRequest.Builder(mediaItem.mediaId, baseRequest.uri)

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadController.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadController.kt
@@ -231,12 +231,8 @@ object DownloadController {
                         put(DownloadConstants.KEY_THUMBNAIL_URL, thumbnailUrl)
 
                         // Add custom metadata if provided
-                        metadata?.let { customMetadata ->
-                            val customMetadataObj = JSONObject()
-                            customMetadata.forEach { (key, value) ->
-                                customMetadataObj.put(key, value)
-                            }
-                            put(DownloadConstants.KEY_CUSTOM_METADATA, customMetadataObj)
+                        if (metadata.isNotEmpty()) {
+                            put(DownloadConstants.KEY_CUSTOM_METADATA, JSONObject(metadata as Map<*, *>))
                         }
                     }.toString()
 

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadItem.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadItem.kt
@@ -14,5 +14,5 @@ data class DownloadItem(
     val downloadedBytes: Long = 0,
     val progressPercentage: Float = 0f,
     val state: Int = 0,
-    val metadata: Map<String, String>? = emptyMap()
+    val metadata: Map<String, String> = emptyMap()
 ) 

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadItem.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadItem.kt
@@ -13,5 +13,6 @@ data class DownloadItem(
     val totalBytes: Long = 0,
     val downloadedBytes: Long = 0,
     val progressPercentage: Float = 0f,
-    val state: Int = 0
+    val state: Int = 0,
+    val metadata: Map<String, String>? = emptyMap()
 ) 


### PR DESCRIPTION
- Introduced downloadMetadata parameter in TPStreamsPlayer.
- Updated DownloadActions, DownloadClient, and DownloadController to handle metadata in the download flow.
- Extended DownloadItem to store metadata associated with each download.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for attaching custom metadata (such as title, thumbnail URL, download date, and category) to downloads.
  * Downloaded items now display associated metadata for easier identification and management.

* **Enhancements**
  * Improved handling and standardization of download-related metadata across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->