### PR TITLE
feat: Expose offlineLicenseExpireTime for DRM downloads

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/DownloadActions.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/DownloadActions.kt
@@ -76,6 +76,7 @@ class DownloadActions(private val view: TPStreamsPlayerView) {
         val tpsPlayer = view.getPlayer() ?: return
         val assetId = tpsPlayer.assetId
         val metadata = tpsPlayer.downloadMetadata ?: emptyMap()
+        val offlineLicenseExpireTime = tpsPlayer.offlineLicenseExpireTime
 
         tpsPlayer.isTokenValid(assetId) { isValid ->
             if (!isValid) {
@@ -86,13 +87,13 @@ class DownloadActions(private val view: TPStreamsPlayerView) {
                     }
     
                     val updatedMediaItem = mediaItem.updateMediaItemDrmConfig(token)
-                    downloadClient.startDownload(updatedMediaItem, resolution, metadata)
+                    downloadClient.startDownload(updatedMediaItem, resolution, metadata, offlineLicenseExpireTime)
                     showToast("Starting download for $resolution", false)
                 }
                 return@isTokenValid
             }
     
-            downloadClient.startDownload(mediaItem, resolution, metadata)
+            downloadClient.startDownload(mediaItem, resolution, metadata, offlineLicenseExpireTime)
             showToast("Starting download for $resolution", false)
         }
     }

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -42,7 +42,8 @@ private constructor(
     private val startAt: Long = 0,
     val enableDownload: Boolean = false,
     private val showDefaultCaptions: Boolean = false,
-    val downloadMetadata: Map<String, String>? = null
+    val downloadMetadata: Map<String, String>? = null,
+    val offlineLicenseExpireTime: Int = 0
 ) : Player by exoPlayer {
 
     interface Listener {
@@ -583,7 +584,8 @@ private constructor(
             startAt: Long = 0,
             enableDownload: Boolean = false,
             showDefaultCaptions: Boolean = false,
-            downloadMetadata: Map<String, String>? = null
+            downloadMetadata: Map<String, String>? = null,
+            offlineLicenseExpireTime: Int = 0
         ): TPStreamsPlayer {
             val (exo, trackSelector) = createExoPlayer(context)
             return TPStreamsPlayer(
@@ -596,7 +598,8 @@ private constructor(
                 startAt,
                 enableDownload,
                 showDefaultCaptions,
-                downloadMetadata)
+                downloadMetadata,
+                offlineLicenseExpireTime)
         }
     }
 }

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadClient.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadClient.kt
@@ -82,8 +82,8 @@ class DownloadClient private constructor(private val context: Context) {
     }
 
 
-    fun startDownload(mediaItem: MediaItem, resolution: String, metadata: Map<String, String>) {
-        DownloadController.startDownload(context, mediaItem, resolution, metadata)
+    fun startDownload(mediaItem: MediaItem, resolution: String, metadata: Map<String, String>, offlineLicenseExpireTime: Int = 0) {
+        DownloadController.startDownload(context, mediaItem, resolution, metadata, offlineLicenseExpireTime)
     }
 
     fun pauseDownload(assetId: String) {


### PR DESCRIPTION
- Introduced offlineLicenseExpireTime parameter in TPStreamsPlayer to specify the desired duration of offline license validity.
- Enables control over license expiration time for DRM-protected downloaded content.