### PR TITLE
fix: start download immediately on permission grant

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/DownloadActions.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/DownloadActions.kt
@@ -3,6 +3,8 @@ package com.tpstreams.player
 import android.os.Build
 import android.util.Log
 import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.fragment.app.FragmentActivity
 import androidx.media3.common.MediaItem
 import androidx.media3.exoplayer.offline.Download
 import com.tpstreams.player.download.DownloadPermissionHandler
@@ -61,14 +63,16 @@ class DownloadActions(private val view: TPStreamsPlayerView) {
         val tpsPlayer = view.getPlayer() ?: return
         val mediaItem = tpsPlayer.currentMediaItem ?: return
         
-        val activity = view.getActivity()
-        if (activity != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            if (!DownloadPermissionHandler.hasNotificationPermission(view.context)) {
-                DownloadPermissionHandler.requestNotificationPermission(activity)
-                return
+        val activity = view.getActivity() ?: return
+        
+        if (activity is FragmentActivity) {
+            DownloadPermissionHandler.requestPermissionIfNeeded(activity) {
+                startDownload(mediaItem, resolution)
             }
+        } else {
+            // Fallback for non-FragmentActivity (should be rare)
+            startDownload(mediaItem, resolution)
         }
-        startDownload(mediaItem, resolution)
     }
     
     private fun startDownload(mediaItem: MediaItem, resolution: String) {

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadPermissionHandler.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadPermissionHandler.kt
@@ -1,38 +1,33 @@
 package com.tpstreams.player.download
 
 import android.Manifest
-import android.app.Activity
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
-import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import androidx.fragment.app.FragmentActivity
 
 object DownloadPermissionHandler {
-    const val NOTIFICATION_PERMISSION_REQUEST_CODE = 2001
-    
     fun hasNotificationPermission(context: Context): Boolean {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             ContextCompat.checkSelfPermission(
-                context,
-                Manifest.permission.POST_NOTIFICATIONS
+                context, Manifest.permission.POST_NOTIFICATIONS
             ) == PackageManager.PERMISSION_GRANTED
         } else {
             true
         }
     }
-    
-    fun requestNotificationPermission(activity: Activity): Boolean {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            if (!hasNotificationPermission(activity)) {
-                ActivityCompat.requestPermissions(
-                    activity,
-                    arrayOf(Manifest.permission.POST_NOTIFICATIONS),
-                    NOTIFICATION_PERMISSION_REQUEST_CODE
-                )
-                return false
-            }
+
+    fun requestPermissionIfNeeded(activity: FragmentActivity, onGranted: () -> Unit) {
+        if (hasNotificationPermission(activity)) {
+            onGranted()
+            return
         }
-        return true
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            NotificationPermissionFragment.request(activity, onGranted)
+        } else {
+            onGranted()
+        }
     }
 } 

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/NotificationPermissionFragment.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/NotificationPermissionFragment.kt
@@ -1,0 +1,53 @@
+package com.tpstreams.player.download
+
+import android.Manifest
+import android.os.Build
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.RequiresApi
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+
+@RequiresApi(Build.VERSION_CODES.TIRAMISU)
+class NotificationPermissionFragment : Fragment() {
+
+    private var onGrantedCallback: (() -> Unit)? = null
+
+    private val permissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (isGranted) {
+            onGrantedCallback?.invoke()
+        } else {
+            Toast.makeText(requireContext(), "Allow notification permission in App settings to download videos", Toast.LENGTH_LONG).show()
+        }
+        parentFragmentManager.beginTransaction().remove(this).commitAllowingStateLoss()
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        retainInstance = true
+    }
+
+    fun requestPermission(callback: () -> Unit) {
+        onGrantedCallback = callback
+        permissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+    }
+
+    companion object {
+        private const val TAG = "NotificationPermissionFragment"
+
+        fun request(activity: FragmentActivity, callback: () -> Unit) {
+            val fragment = NotificationPermissionFragment()
+            fragment.onGrantedCallback = callback
+
+            activity.supportFragmentManager.beginTransaction()
+                .add(fragment, TAG)
+                .commitAllowingStateLoss()
+
+            activity.supportFragmentManager.executePendingTransactions()
+            fragment.requestPermission(callback)
+        }
+    }
+} 


### PR DESCRIPTION
- Fixed an issue where downloads did not start automatically after the user granted notification permission.
- Introduced NotificationPermissionFragment to handle runtime permission requests using FragmentActivity.
- Updated DownloadPermissionHandler to invoke the download callback immediately after permission is granted.