### PR TITLE
fix: prevent pause/resume of one download from affecting all

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadController.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadController.kt
@@ -278,7 +278,6 @@ object DownloadController {
         if (isInitialized) {
             downloadManager.setStopReason(id, STOP_REASON_PAUSED)
         }
-        TPSDownloadService.pauseDownloads(context)
     }
     
     fun resumeDownload(context: Context, id: String) {
@@ -286,7 +285,6 @@ object DownloadController {
         if (isInitialized) {
             downloadManager.setStopReason(id, STOP_REASON_NONE)
         }
-        TPSDownloadService.resumeDownloads(context)
     }
     
     fun removeDownload(context: Context, id: String) {

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadController.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadController.kt
@@ -275,16 +275,12 @@ object DownloadController {
     
     fun pauseDownload(context: Context, id: String) {
         Log.d(TAG, "Pausing download: $id")
-        if (isInitialized) {
-            downloadManager.setStopReason(id, STOP_REASON_PAUSED)
-        }
+        getDownloadManager(context).setStopReason(id, STOP_REASON_PAUSED)
     }
     
     fun resumeDownload(context: Context, id: String) {
         Log.d(TAG, "Resuming download: $id")
-        if (isInitialized) {
-            downloadManager.setStopReason(id, STOP_REASON_NONE)
-        }
+        getDownloadManager(context).setStopReason(id, STOP_REASON_NONE)
     }
     
     fun removeDownload(context: Context, id: String) {


### PR DESCRIPTION
- Removed global pause/resume service calls from pauseDownload() and resumeDownload() methods.
- Now only the targeted download is affected using downloadManager.setStopReason.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated download pause and resume behavior to improve internal handling, with no visible changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->