### PR TITLE
fix: update download progress UI continuously during downloads

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadClient.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadClient.kt
@@ -23,11 +23,19 @@ class DownloadClient private constructor(private val context: Context) {
         listeners.forEach { it.onDownloadsChanged() }
     }
     
+    private val PROGRESS_UPDATE_INTERVAL_MS = 1000L
     private val progressHandler = Handler(Looper.getMainLooper())
     private val progressRunnable = object : Runnable {
         override fun run() {
-            listeners.forEach { it.onDownloadsChanged() }
-            progressHandler.postDelayed(this, 1000)
+            listeners.forEach { listener ->
+                try {
+                    listener.onDownloadsChanged()
+                } catch (e: Exception) {
+                    Log.e(TAG, "Error notifying listener: ${e.message}", e)
+                }
+            }
+            
+            progressHandler.postDelayed(this, PROGRESS_UPDATE_INTERVAL_MS)
         }
     }
 

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadClient.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadClient.kt
@@ -1,6 +1,8 @@
 package com.tpstreams.player.download
 
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import androidx.media3.common.MediaItem
 import androidx.media3.common.util.UnstableApi
@@ -20,7 +22,14 @@ class DownloadClient private constructor(private val context: Context) {
     private val repository = DownloadRepository(context) {
         listeners.forEach { it.onDownloadsChanged() }
     }
-
+    
+    private val progressHandler = Handler(Looper.getMainLooper())
+    private val progressRunnable = object : Runnable {
+        override fun run() {
+            listeners.forEach { it.onDownloadsChanged() }
+            progressHandler.postDelayed(this, 1000)
+        }
+    }
 
     fun isDownloaded(assetId: String): Boolean = repository.getDownload(assetId)?.state == Download.STATE_COMPLETED
 
@@ -105,10 +114,24 @@ class DownloadClient private constructor(private val context: Context) {
 
     fun addListener(listener: Listener) {
         listeners.add(listener)
+        if (listeners.size == 1) {
+            startProgressUpdates()
+        }
     }
 
     fun removeListener(listener: Listener) {
         listeners.remove(listener)
+        if (listeners.isEmpty()) {
+            stopProgressUpdates()
+        }
+    }
+    
+    private fun startProgressUpdates() {
+        progressHandler.post(progressRunnable)
+    }
+    
+    private fun stopProgressUpdates() {
+        progressHandler.removeCallbacks(progressRunnable)
     }
 
     private inner class DownloadRepository(


### PR DESCRIPTION
- Added a Handler and Runnable in DownloadClient to emit periodic progress updates.
- Ensures download progress is reflected in real-time during active downloads.
- Updates start when the first listener is added and stop when all listeners are removed.
- Fixes the issue where progress UI only updated after navigating away and back to the screen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Download progress updates are now provided every second, ensuring listeners receive regular and timely information during downloads.
  * Progress updates automatically start when listeners are present and stop when no listeners remain, optimizing resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->