### PR TITLE
fix: incorrect total size in DownloadItem

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/DownloadActions.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/DownloadActions.kt
@@ -85,7 +85,6 @@ class DownloadActions(private val view: TPStreamsPlayerView) {
         val offlineLicenseExpireTime = tpsPlayer.offlineLicenseExpireTime
         
         val trackBitrates = tpsPlayer.getResolutionBitrates()
-        val bitrate = trackBitrates[resolution] ?: 0
         val durationMs = tpsPlayer.duration
 
         val totalSize = getDownloadSize(trackBitrates, resolution, durationMs)
@@ -188,10 +187,12 @@ class DownloadActions(private val view: TPStreamsPlayerView) {
         }
     }
 
-    fun getDownloadSize(trackBitrates: Map<String, Int>, resolution: String, durationMs: Long): Long {
-        val bitrate = trackBitrates[resolution] ?: 0
+    private fun getDownloadSize(trackBitrates: Map<String, Int>, resolution: String, durationMs: Long): Long {
+        val bitrate = trackBitrates[resolution] ?: return 0
+        if (bitrate <= 0 || durationMs <= 0) return 0
+
         val durationSeconds = durationMs / 1000.0
         val sizeBytes = (bitrate.toLong() * durationSeconds / 8.0).toLong()
-        return sizeBytes.toLong()
+        return sizeBytes
     }
 } 

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadConstants.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadConstants.kt
@@ -4,4 +4,5 @@ object DownloadConstants {
     const val KEY_CUSTOM_METADATA = "customMetadata"
     const val KEY_TITLE = "title"
     const val KEY_THUMBNAIL_URL = "thumbnailUrl"
+    const val KEY_CALCULATED_SIZE_BYTES = "calculatedSizeBytes"
 } 

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadController.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadController.kt
@@ -207,7 +207,7 @@ object DownloadController {
         return DefaultDataSource.Factory(context, httpDataSourceFactory)
     }
     
-    fun startDownload(context: Context, mediaItem: MediaItem, resolution: String, metadata: Map<String, String>, offlineLicenseExpireTime: Int = 0) {
+    fun startDownload(context: Context, mediaItem: MediaItem, resolution: String, metadata: Map<String, String>, totalSize: Long = 0, offlineLicenseExpireTime: Int = 0) {
         Log.d(TAG, "Preparing download for: ${mediaItem.mediaId}")
         val title = mediaItem.mediaMetadata.title?.toString() ?: "Undefined"
         val thumbnailUrl = mediaItem.mediaMetadata.artworkUri?.toString() ?: ""
@@ -230,6 +230,7 @@ object DownloadController {
                     val metadataJson = JSONObject().apply {
                         put(DownloadConstants.KEY_TITLE, title)
                         put(DownloadConstants.KEY_THUMBNAIL_URL, thumbnailUrl)
+                        put(DownloadConstants.KEY_CALCULATED_SIZE_BYTES, totalSize)
 
                         // Add custom metadata if provided
                         if (metadata.isNotEmpty()) {


### PR DESCRIPTION
- Previously, the `totalSize` in `DownloadItem` was set to -1 because `Download.contentLength` returned -1 for HLS/DASH streams. This change adds a fallback to compute the total size using resolution bitrate and video duration when contentLength is unavailable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app now calculates and displays the estimated total download size based on the selected resolution and media duration before starting a download.

* **Improvements**
  * Download size information is now included in download requests, providing more accurate progress and storage usage details during downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->