### PR TITLE
fix: Null pointer when parsing metadata JSON

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadClient.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadClient.kt
@@ -79,8 +79,8 @@ class DownloadClient private constructor(private val context: Context) {
                 computedSize = json.optLong(DownloadConstants.KEY_CALCULATED_SIZE_BYTES, 0)
 
                 val metadataObj = json.optJSONObject(DownloadConstants.KEY_CUSTOM_METADATA)
-                if (metadataObj != null) {
-                    val map = metadataObj.keys().asSequence().associateWith { metadataObj.getString(it) }
+                metadataObj?.let {
+                    val map = it.keys().asSequence().associateWith { key -> it.getString(key) }
                     customMetadata.putAll(map)
                 }
             }

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadClient.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadClient.kt
@@ -79,8 +79,10 @@ class DownloadClient private constructor(private val context: Context) {
                 computedSize = json.optLong(DownloadConstants.KEY_CALCULATED_SIZE_BYTES, 0)
 
                 val metadataObj = json.optJSONObject(DownloadConstants.KEY_CUSTOM_METADATA)
-                val map = metadataObj.keys().asSequence().associateWith { metadataObj.getString(it) }
-                customMetadata.putAll(map)
+                if (metadataObj != null) {
+                    val map = metadataObj.keys().asSequence().associateWith { metadataObj.getString(it) }
+                    customMetadata.putAll(map)
+                }
             }
         } catch (e: Exception) {
             Log.e(TAG, "Error extracting metadata from download: ${e.message}")


### PR DESCRIPTION
- Fixes a crash that occurred when attempting to extract keys from a null metadata JSONObject during the download process.
- A null check is added to ensure the metadata is valid before accessing its contents.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app now calculates and displays the estimated total size of downloads before they start, improving transparency for users.
* **Improvements**
  * Enhanced download management by including estimated download size information when initiating and tracking downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->