### PR TITLE
fix: restrict download to selected resolution only

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadController.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadController.kt
@@ -31,6 +31,8 @@ import java.util.concurrent.Executors
 import java.util.concurrent.ExecutorService
 import androidx.media3.common.Format
 import androidx.media3.common.C
+import androidx.media3.common.TrackSelectionParameters
+import androidx.media3.exoplayer.DefaultRenderersFactory
 import org.json.JSONObject
 import android.net.Uri
 
@@ -213,11 +215,19 @@ object DownloadController {
         val thumbnailUrl = mediaItem.mediaMetadata.artworkUri?.toString() ?: ""
         
         Log.d(TAG, "Download metadata - Title: $title, Thumbnail: $thumbnailUrl")
-        
+        val targetHeight = resolution.removeSuffix("p").toIntOrNull() ?: 0
+        val trackSelectionParameters = if (targetHeight > 0) {
+            TrackSelectionParameters.Builder()
+                .setMaxVideoSize(Int.MAX_VALUE, targetHeight)
+                .setMinVideoSize(0, targetHeight)
+                .build()
+        } else {
+            TrackSelectionParameters.Builder().build()
+        }
         val helper = DownloadHelper.forMediaItem(
-            context,
             mediaItem,
-            null,
+            trackSelectionParameters,
+            DefaultRenderersFactory(context),
             getDataSourceFactory(context)
         )
         


### PR DESCRIPTION
- Previously, when a specific resolution was selected for download, the system incorrectly triggered downloads for all available resolutions. 
- This fix ensures that only the user-selected resolution is downloaded, avoiding unnecessary bandwidth usage and storage consumption.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Video downloads now support selecting a specific resolution, allowing users to choose their preferred video quality before downloading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->