### PR TITLE
fix: improve size calculation for download files

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -361,7 +361,7 @@ private constructor(
 
         return resolutions.sortedDescending()
     }
-    
+
     @OptIn(UnstableApi::class)
     fun getResolutionBitrates(): Map<String, Int> {
         val bitrateMap = mapOf(

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -362,36 +362,18 @@ private constructor(
         return resolutions.sortedDescending()
     }
 
+    
+    
     @OptIn(UnstableApi::class)
     fun getResolutionBitrates(): Map<String, Int> {
-        val mappedTrackInfo = trackSelector.currentMappedTrackInfo ?: return emptyMap()
-        
-        val resolutionBitrateMap = mutableMapOf<Int, Int>()
-        
-        for (rendererIndex in 0 until mappedTrackInfo.rendererCount) {
-            if (mappedTrackInfo.getRendererType(rendererIndex) == C.TRACK_TYPE_VIDEO) {
-                val trackGroups = mappedTrackInfo.getTrackGroups(rendererIndex)
-                for (groupIndex in 0 until trackGroups.length) {
-                    val group = trackGroups.get(groupIndex)
-                    for (trackIndex in 0 until group.length) {
-                        val format = group.getFormat(trackIndex)
-                        if (format.height != Format.NO_VALUE && format.bitrate != Format.NO_VALUE) {
-                            // Store the resolution and its corresponding bitrate
-                            resolutionBitrateMap[format.height] = format.bitrate
-                        }
-                    }
-                }
-            }
-        }
-        
-        // Convert to final map format with string keys
-        val combinedBitrates = mutableMapOf<String, Int>()
-        for ((resolution, bitrate) in resolutionBitrateMap) {
-            combinedBitrates["${resolution}p"] = bitrate
-        }
-        
-        Log.d("TPStreamsPlayer", "Resolution-bitrate map: $combinedBitrates")
-        return combinedBitrates
+        val bitrateMap = mapOf(
+            "240p" to 192_000,
+            "360p" to 300_000,
+            "480p" to 400_000,    
+            "720p" to 900_000,
+            "1080p" to 1_500_000
+        )
+        return bitrateMap
     }
 
     @OptIn(UnstableApi::class)

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -30,6 +30,7 @@ import androidx.media3.exoplayer.offline.DownloadRequest
 import androidx.media3.datasource.cache.CacheDataSource
 import androidx.media3.common.MediaMetadata
 import androidx.media3.exoplayer.trackselection.MappingTrackSelector
+import com.tpstreams.player.download.DownloadConstants
 
 class TPStreamsPlayer @OptIn(UnstableApi::class)
 private constructor(
@@ -364,14 +365,13 @@ private constructor(
 
     @OptIn(UnstableApi::class)
     fun getResolutionBitrates(): Map<String, Int> {
-        val bitrateMap = mapOf(
-            "240p" to 192_000,
-            "360p" to 300_000,
-            "480p" to 400_000,    
-            "720p" to 900_000,
-            "1080p" to 1_500_000
+        return mapOf(
+            "240p" to DownloadConstants.BITRATE_240P,
+            "360p" to DownloadConstants.BITRATE_360P,
+            "480p" to DownloadConstants.BITRATE_480P,    
+            "720p" to DownloadConstants.BITRATE_720P,
+            "1080p" to DownloadConstants.BITRATE_1080P
         )
-        return bitrateMap
     }
 
     @OptIn(UnstableApi::class)

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -361,8 +361,6 @@ private constructor(
 
         return resolutions.sortedDescending()
     }
-
-    
     
     @OptIn(UnstableApi::class)
     fun getResolutionBitrates(): Map<String, Int> {

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadConstants.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadConstants.kt
@@ -5,4 +5,13 @@ object DownloadConstants {
     const val KEY_TITLE = "title"
     const val KEY_THUMBNAIL_URL = "thumbnailUrl"
     const val KEY_CALCULATED_SIZE_BYTES = "calculatedSizeBytes"
+
+    const val BITRATE_AUDIO_LOW = 72_000
+    const val BITRATE_AUDIO_HIGH = 128_000
+
+    const val BITRATE_240P = 192_000 + BITRATE_AUDIO_LOW
+    const val BITRATE_360P = 400_000 + BITRATE_AUDIO_LOW
+    const val BITRATE_480P = 500_000 + BITRATE_AUDIO_HIGH
+    const val BITRATE_720P = 1_000_000 + BITRATE_AUDIO_HIGH
+    const val BITRATE_1080P = 2_500_000 + BITRATE_AUDIO_HIGH
 } 


### PR DESCRIPTION
- Previously, the computed total size of the download file differed significantly from the actual downloaded bytes because the TrackSelector returned lower bitrate values. 
- This update replaces those values with the bitrates defined in the transcoding backend, resulting in a more accurate and closer size computation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated video resolution bitrate information to use fixed, predefined values instead of dynamically extracting them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->