### PR TITLE
feat: add DRM session manager for license expiry handling

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -110,7 +110,8 @@ private constructor(
             }
             
             override fun onPlayerError(error: PlaybackException) {
-                if (error.cause is DrmSession.DrmSessionException) return
+                if (error.cause is DrmSession.DrmSessionException || 
+                    error.cause is android.media.MediaCodec.CryptoException) return
                 Log.e("TPStreamsPlayer", "Player error: ${error.message}", error)
             }
             
@@ -352,7 +353,11 @@ private constructor(
      */
     override fun getPlaybackState(): Int = exoPlayer.playbackState
 
-    override fun release() = exoPlayer.release()
+    override fun release() {
+        exoPlayer.removeListener(drmSessionManager)
+        drmSessionManager.release()
+        exoPlayer.release()
+    }
 
     @OptIn(UnstableApi::class)
     fun getTrackSelector(): DefaultTrackSelector = trackSelector

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/drm/DrmSessionManager.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/drm/DrmSessionManager.kt
@@ -1,0 +1,114 @@
+package com.tpstreams.player.drm
+
+import android.media.MediaDrm
+import android.util.Log
+import androidx.media3.common.Player
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaItem.DrmConfiguration
+import androidx.media3.common.C
+import androidx.media3.exoplayer.drm.DrmSession
+import android.media.MediaDrm.MediaDrmStateException
+import android.os.Build
+import androidx.annotation.OptIn
+import androidx.annotation.RequiresApi
+import androidx.media3.common.util.UnstableApi
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class DrmSessionManager(
+    private val assetId: String,
+    private val isTokenValid: (String, (Boolean) -> Unit) -> Unit,
+    private val onAccessTokenExpired: (String, (String) -> Unit) -> Unit,
+    private val accessToken: String,
+    private val organizationId: String?,
+    private val exoPlayer: Player
+) : Player.Listener {
+
+    @OptIn(UnstableApi::class)
+    @RequiresApi(Build.VERSION_CODES.S)
+    override fun onPlayerError(error: PlaybackException) {
+        val cause = error.cause
+        if (cause is DrmSession.DrmSessionException &&
+            cause.cause is MediaDrmStateException) {
+            val drmStateException = cause.cause as MediaDrmStateException
+            when (drmStateException.getErrorCode()) {
+                MediaDrm.ErrorCodes.ERROR_LICENSE_POLICY -> {
+                    Log.w("DrmSessionManager", "DRM license policy error for asset: $assetId")
+                    handleDrmLicenseExpiry()
+                }
+                MediaDrm.ErrorCodes.ERROR_KEY_EXPIRED -> {
+                    Log.w("DrmSessionManager", "DRM license expired for asset: $assetId")
+                    handleDrmLicenseExpiry()
+                }
+                else -> {
+                    Log.e("DrmSessionManager", "DRM error code: ${drmStateException.getErrorCode()} for asset: $assetId")
+                    handleDrmLicenseExpiry()
+                }
+            }
+        }
+    }
+
+    private fun handleDrmLicenseExpiry() {
+        Log.d("DrmSessionManager", "Handling DRM license expiry for asset: $assetId")
+        isTokenValid(assetId) { isValid ->
+            if (isValid) {
+                Log.d("DrmSessionManager", "Token is still valid, retrying with existing token")
+                retryPlayback(accessToken)
+            } else {
+                Log.d("DrmSessionManager", "Token is expired, requesting new token")
+                onAccessTokenExpired(assetId) { newToken ->
+                    if (newToken.isNotEmpty()) {
+                        Log.d("DrmSessionManager", "Received new token, retrying playback")
+                        retryPlayback(newToken)
+                    } else {
+                        Log.e("DrmSessionManager", "Failed to get new token for DRM license renewal")
+                    }
+                }
+            }
+        }
+    }
+
+    private fun retryPlayback(token: String) {
+        val currentMediaItem = exoPlayer.currentMediaItem ?: return
+        val orgId = organizationId ?: return
+        
+        Log.d("DrmSessionManager", "Retrying playback with token for asset: $assetId")
+        
+        val updatedMediaItem = currentMediaItem.buildUpon()
+            .apply {
+                val currentDrmConfig = currentMediaItem.localConfiguration?.drmConfiguration
+                if (currentDrmConfig != null) {
+                    val licenseUrl = "https://app.tpstreams.com/api/v1/$orgId/assets/$assetId/drm_license/?access_token=$token"
+                    val drmHeaders = mapOf("Authorization" to "Bearer $token")
+                    
+                    val newDrmConfig = DrmConfiguration.Builder(C.WIDEVINE_UUID)
+                        .setLicenseUri(licenseUrl)
+                        .setLicenseRequestHeaders(drmHeaders)
+                        .setMultiSession(true)
+                        .build()
+                    
+                    setDrmConfiguration(newDrmConfig)
+                }
+            }
+            .build()
+
+        CoroutineScope(Dispatchers.Main).launch {
+            val currentPosition = exoPlayer.currentPosition
+            val wasPlaying = exoPlayer.isPlaying
+            
+            exoPlayer.setMediaItem(updatedMediaItem)
+            exoPlayer.prepare()
+            
+            if (currentPosition > 0) {
+                exoPlayer.seekTo(currentPosition)
+            }
+            if (wasPlaying) {
+                exoPlayer.play()
+            }
+            
+            Log.d("DrmSessionManager", "Successfully retried playback with updated DRM license")
+        }
+    }
+} 


### PR DESCRIPTION
- Create DrmSessionManager to handle DRM license expiration errors
- Implement automatic token validation and renewal flow
- Add retry mechanism for offline playback with expired licenses
- Separate DRM logic from main player class for better maintainability
- Emit onAccessTokenExpired event when token is invalid
- Preserve playback position and state during license renewal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of DRM license errors during media playback, including automatic token validation and renewal for uninterrupted viewing.
* **Bug Fixes**
  * Player now ignores specific DRM-related errors, reducing unnecessary error notifications during playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->