### PR TITLE
fix: add toast message for download actions

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/DownloadActions.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/DownloadActions.kt
@@ -141,6 +141,7 @@ class DownloadActions(private val view: TPStreamsPlayerView) {
         val assetId = mediaItem.mediaId
         
         DownloadClient.getInstance(view.context).removeDownload(assetId)
+        showToast("Download deleted", false)
     }
     
     fun pauseCurrentDownload() {
@@ -149,6 +150,7 @@ class DownloadActions(private val view: TPStreamsPlayerView) {
         val assetId = mediaItem.mediaId
         
         DownloadClient.getInstance(view.context).pauseDownload(assetId)
+        showToast("Download paused", false)
     }
     
     fun resumeCurrentDownload() {
@@ -157,6 +159,7 @@ class DownloadActions(private val view: TPStreamsPlayerView) {
         val assetId = mediaItem.mediaId
         
         DownloadClient.getInstance(view.context).resumeDownload(assetId)
+        showToast("Download resumed", false)
     }
 
     fun getCurrentDownloadStatus(): String {


### PR DESCRIPTION
- Add toast message "Download deleted" when download is removed
- Add toast message "Download paused" when download is paused  
- Add toast message "Download resumed" when download is resumed
- Improve user experience with immediate feedback for download operations