### PR TITLE
fix: add 15 days default for offline license expiry

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -46,7 +46,7 @@ private constructor(
     val enableDownload: Boolean = false,
     private val showDefaultCaptions: Boolean = false,
     val downloadMetadata: Map<String, String>? = null,
-    val offlineLicenseExpireTime: Int = DownloadConstants.FIFTEEN_DAYS_IN_SECONDS
+    val offlineLicenseExpireTime: Long = DownloadConstants.FIFTEEN_DAYS_IN_SECONDS
 ) : Player by exoPlayer {
 
     interface Listener {
@@ -587,7 +587,7 @@ private constructor(
             enableDownload: Boolean = false,
             showDefaultCaptions: Boolean = false,
             downloadMetadata: Map<String, String>? = null,
-            offlineLicenseExpireTime: Int = DownloadConstants.FIFTEEN_DAYS_IN_SECONDS
+            offlineLicenseExpireTime: Long = DownloadConstants.FIFTEEN_DAYS_IN_SECONDS
         ): TPStreamsPlayer {
             val (exo, trackSelector) = createExoPlayer(context)
             return TPStreamsPlayer(

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadClient.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadClient.kt
@@ -107,7 +107,7 @@ class DownloadClient private constructor(private val context: Context) {
     }
 
 
-    fun startDownload(mediaItem: MediaItem, resolution: String, metadata: Map<String, String>, totalSize: Long = 0, offlineLicenseExpireTime: Int = 0) {
+    fun startDownload(mediaItem: MediaItem, resolution: String, metadata: Map<String, String>, totalSize: Long = 0, offlineLicenseExpireTime: Long = DownloadConstants.FIFTEEN_DAYS_IN_SECONDS) {
         DownloadController.startDownload(context, mediaItem, resolution, metadata, totalSize, offlineLicenseExpireTime)
     }
 

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadConstants.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadConstants.kt
@@ -6,7 +6,7 @@ object DownloadConstants {
     const val KEY_THUMBNAIL_URL = "thumbnailUrl"
     const val KEY_CALCULATED_SIZE_BYTES = "calculatedSizeBytes"
 
-    const val FIFTEEN_DAYS_IN_SECONDS = 15 * 24 * 60 * 60
+    const val FIFTEEN_DAYS_IN_SECONDS = 15L * 24 * 60 * 60
 
     const val BITRATE_AUDIO_LOW = 72_000
     const val BITRATE_AUDIO_HIGH = 128_000

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadController.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadController.kt
@@ -209,7 +209,7 @@ object DownloadController {
         return DefaultDataSource.Factory(context, httpDataSourceFactory)
     }
     
-    fun startDownload(context: Context, mediaItem: MediaItem, resolution: String, metadata: Map<String, String>, totalSize: Long = 0, offlineLicenseExpireTime: Int = 0) {
+    fun startDownload(context: Context, mediaItem: MediaItem, resolution: String, metadata: Map<String, String>, totalSize: Long = 0, offlineLicenseExpireTime: Long = DownloadConstants.FIFTEEN_DAYS_IN_SECONDS) {
         Log.d(TAG, "Preparing download for: ${mediaItem.mediaId}")
         val title = mediaItem.mediaMetadata.title?.toString() ?: "Undefined"
         val thumbnailUrl = mediaItem.mediaMetadata.artworkUri?.toString() ?: ""
@@ -309,7 +309,7 @@ object DownloadController {
         drmConfig: MediaItem.DrmConfiguration,
         helper: DownloadHelper,
         baseRequest: DownloadRequest,
-        offlineLicenseExpireTime: Int = 0
+        offlineLicenseExpireTime: Long = DownloadConstants.FIFTEEN_DAYS_IN_SECONDS
     ): DownloadRequest? {
         val licenseUri = drmConfig.licenseUri?.toString() ?: return null
         val uriBuilder = Uri.parse(licenseUri).buildUpon()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The default expiration time for offline licenses is now set to fifteen days.
* **Chores**
  * Added a new constant representing fifteen days for improved license management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->