### PR TITLE
fix: Prevent downloads stuck in QUEUED state after app restart

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadController.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadController.kt
@@ -302,7 +302,7 @@ object DownloadController {
     fun resumeDownload(context: Context, id: String) {
         Log.d(TAG, "Resuming download: $id")
         getDownloadManager(context).setStopReason(id, STOP_REASON_NONE)
-       TPSDownloadService.resumeDownloads(context)
+        TPSDownloadService.resumeDownloads(context)
     }
     
     fun removeDownload(context: Context, id: String) {

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadController.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadController.kt
@@ -302,6 +302,7 @@ object DownloadController {
     fun resumeDownload(context: Context, id: String) {
         Log.d(TAG, "Resuming download: $id")
         getDownloadManager(context).setStopReason(id, STOP_REASON_NONE)
+       TPSDownloadService.resumeDownloads(context)
     }
     
     fun removeDownload(context: Context, id: String) {


### PR DESCRIPTION
- Previously, downloads were stuck in QUEUED state after app restart due to DownloadManager not reprocessing them
- Triggered TPSDownloadService.resumeDownloads() to wake up and process pending downloads
- Ensures stuck downloads resume properly