### PR TITLE
fix: Block audio capture for DRM-protected videos

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -219,17 +219,7 @@ private constructor(
         setSubtitleMetadata(result.subtitleMetadata)
 
         playerScope.launch(Dispatchers.Main) {
-                    val capturePolicy = if (assetInfo.enableDrm) {
-                        C.ALLOW_CAPTURE_BY_NONE
-                    } else {
-                        C.ALLOW_CAPTURE_BY_ALL
-                    }
-
-                    val audioAttributes = AudioAttributes.Builder()
-                        .setUsage(C.USAGE_MEDIA)
-                        .setContentType(C.AUDIO_CONTENT_TYPE_MOVIE)
-                        .setAllowedCapturePolicy(capturePolicy)
-                        .build()
+                    val audioAttributes = buildAudioAttributes(assetInfo.enableDrm)
 
                     exoPlayer.setAudioAttributes(audioAttributes, true)
                     exoPlayer.setMediaItem(result.mediaItem)
@@ -262,25 +252,15 @@ private constructor(
             if (download != null) {
                 Log.d("TPStreamsPlayer", "Found downloaded content for $assetId, using local version")
 
+                val downloadedMediaItem = DownloadController.buildMediaItemFromDownload(download)
+                if (downloadedMediaItem == null) {
+                    Log.e("TPStreamsPlayer", "Failed to build media item from download for $assetId")
+                    return false
+                }
+
                 playerScope.launch {
-                    val downloadedMediaItem = DownloadController.buildMediaItemFromDownload(download)
-                    if (downloadedMediaItem == null) {
-                        Log.e("TPStreamsPlayer", "Failed to build media item from download for $assetId")
-                        return@launch
-                    }
-
                     val isDrm = download.request.keySetId != null
-                    val capturePolicy = if (isDrm) {
-                        C.ALLOW_CAPTURE_BY_NONE
-                    } else {
-                        C.ALLOW_CAPTURE_BY_ALL
-                    }
-
-                    val audioAttributes = AudioAttributes.Builder()
-                        .setUsage(C.USAGE_MEDIA)
-                        .setContentType(C.AUDIO_CONTENT_TYPE_MOVIE)
-                        .setAllowedCapturePolicy(capturePolicy)
-                        .build()
+                    val audioAttributes = buildAudioAttributes(isDrm)
 
                     exoPlayer.setAudioAttributes(audioAttributes, true)
                     exoPlayer.setMediaItem(downloadedMediaItem)
@@ -299,21 +279,25 @@ private constructor(
         return false
     }
 
+    private fun buildAudioAttributes(isDrm: Boolean): AudioAttributes {
+        val capturePolicy = if (isDrm) {
+            C.ALLOW_CAPTURE_BY_NONE
+        } else {
+            C.ALLOW_CAPTURE_BY_ALL
+        }
+
+        return AudioAttributes.Builder()
+            .setUsage(C.USAGE_MEDIA)
+            .setContentType(C.AUDIO_CONTENT_TYPE_MOVIE)
+            .setAllowedCapturePolicy(capturePolicy)
+            .build()
+    }
+
     @OptIn(UnstableApi::class)
     fun refreshPlaybackWithDownloadMediaItem(mediaItem: MediaItem) {
         playerScope.launch {
             val isDrm = mediaItem.localConfiguration?.drmConfiguration != null
-            val capturePolicy = if (isDrm) {
-                C.ALLOW_CAPTURE_BY_NONE
-            } else {
-                C.ALLOW_CAPTURE_BY_ALL
-            }
-
-            val audioAttributes = AudioAttributes.Builder()
-                .setUsage(C.USAGE_MEDIA)
-                .setContentType(C.AUDIO_CONTENT_TYPE_MOVIE)
-                .setAllowedCapturePolicy(capturePolicy)
-                .build()
+            val audioAttributes = buildAudioAttributes(isDrm)
 
             val currentPosition = exoPlayer.currentPosition
             exoPlayer.stop()

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.media.MediaCodec
 import android.util.Log
 import androidx.annotation.OptIn
+import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaItem.DrmConfiguration
@@ -217,9 +218,24 @@ private constructor(
         val result = MediaItemUtils.buildMediaItem(assetInfo, title, orgId, assetId, accessToken)
         setSubtitleMetadata(result.subtitleMetadata)
 
-        exoPlayer.setMediaItem(result.mediaItem)
-        exoPlayer.prepare()
-        isPrepared = true
+        playerScope.launch(Dispatchers.Main) {
+                    val capturePolicy = if (assetInfo.enableDrm) {
+                        C.ALLOW_CAPTURE_BY_NONE
+                    } else {
+                        C.ALLOW_CAPTURE_BY_ALL
+                    }
+
+                    val audioAttributes = AudioAttributes.Builder()
+                        .setUsage(C.USAGE_MEDIA)
+                        .setContentType(C.AUDIO_CONTENT_TYPE_MOVIE)
+                        .setAllowedCapturePolicy(capturePolicy)
+                        .build()
+
+                    exoPlayer.setAudioAttributes(audioAttributes, true)
+                    exoPlayer.setMediaItem(result.mediaItem)
+                    exoPlayer.prepare()
+                    isPrepared = true
+                }
 
         if (shouldAutoPlay || requestedPlay) {
             exoPlayer.play()
@@ -246,13 +262,27 @@ private constructor(
             if (download != null) {
                 Log.d("TPStreamsPlayer", "Found downloaded content for $assetId, using local version")
 
-                val downloadedMediaItem = DownloadController.buildMediaItemFromDownload(download)
-                if (downloadedMediaItem == null) {
-                    Log.e("TPStreamsPlayer", "Failed to build media item from download for $assetId")
-                    return false
-                }
-                
                 playerScope.launch {
+                    val downloadedMediaItem = DownloadController.buildMediaItemFromDownload(download)
+                    if (downloadedMediaItem == null) {
+                        Log.e("TPStreamsPlayer", "Failed to build media item from download for $assetId")
+                        return@launch
+                    }
+
+                    val isDrm = download.request.keySetId != null
+                    val capturePolicy = if (isDrm) {
+                        C.ALLOW_CAPTURE_BY_NONE
+                    } else {
+                        C.ALLOW_CAPTURE_BY_ALL
+                    }
+
+                    val audioAttributes = AudioAttributes.Builder()
+                        .setUsage(C.USAGE_MEDIA)
+                        .setContentType(C.AUDIO_CONTENT_TYPE_MOVIE)
+                        .setAllowedCapturePolicy(capturePolicy)
+                        .build()
+
+                    exoPlayer.setAudioAttributes(audioAttributes, true)
                     exoPlayer.setMediaItem(downloadedMediaItem)
                     exoPlayer.prepare()
                     isPrepared = true
@@ -272,8 +302,22 @@ private constructor(
     @OptIn(UnstableApi::class)
     fun refreshPlaybackWithDownloadMediaItem(mediaItem: MediaItem) {
         playerScope.launch {
+            val isDrm = mediaItem.localConfiguration?.drmConfiguration != null
+            val capturePolicy = if (isDrm) {
+                C.ALLOW_CAPTURE_BY_NONE
+            } else {
+                C.ALLOW_CAPTURE_BY_ALL
+            }
+
+            val audioAttributes = AudioAttributes.Builder()
+                .setUsage(C.USAGE_MEDIA)
+                .setContentType(C.AUDIO_CONTENT_TYPE_MOVIE)
+                .setAllowedCapturePolicy(capturePolicy)
+                .build()
+
             val currentPosition = exoPlayer.currentPosition
             exoPlayer.stop()
+            exoPlayer.setAudioAttributes(audioAttributes, true)
             exoPlayer.clearMediaItems()
             
             exoPlayer.setMediaItem(mediaItem)
@@ -580,6 +624,14 @@ private constructor(
             return ExoPlayer.Builder(context)
                 .setMediaSourceFactory(mediaSourceFactory)
                 .setTrackSelector(trackSelector)
+                .setAudioAttributes(
+                    AudioAttributes.Builder()
+                        .setUsage(C.USAGE_MEDIA)
+                        .setContentType(C.AUDIO_CONTENT_TYPE_MOVIE)
+                        .setAllowedCapturePolicy(C.ALLOW_CAPTURE_BY_NONE)
+                        .build(), 
+                    true
+                )
                 .build() to trackSelector
         }
 

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadController.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadController.kt
@@ -618,7 +618,7 @@ object DownloadController {
     fun buildMediaItemFromDownload(download: Download): MediaItem? {
         val request = download.request
         val builder = request.toMediaItem().buildUpon()
-            .setMediaId(request.id) // Explicitly set the mediaId to ensure it matches the assetId
+            .setMediaId(request.id)
     
         val keySetId = request.keySetId
         val licenseUri = request.data.toString(Charsets.UTF_8)
@@ -626,6 +626,11 @@ object DownloadController {
         if (keySetId != null) {
             if (licenseUri.isEmpty()) {
                 Log.e("TPStreamsPlayer", "Missing DRM license URI for ${request.id}, skipping playback")
+                return null
+            }
+    
+            if (!isValidLicenseUri(licenseUri)) {
+                Log.e("TPStreamsPlayer", "Invalid DRM license URI for ${request.id}, skipping playback")
                 return null
             }
     
@@ -641,6 +646,15 @@ object DownloadController {
         
         Log.d("TPStreamsPlayer", "Building media item from download with ID: ${request.id}")
         return builder.build()
+    }
+
+    private fun isValidLicenseUri(uri: String): Boolean {
+        return try {
+            val parsedUri = Uri.parse(uri)
+            parsedUri.scheme == "https" && parsedUri.host == "app.tpstreams.com"
+        } catch (e: Exception) {
+            false
+        }
     }
 
     


### PR DESCRIPTION
- Prevent audio recording during playback of DRM-protected videos.
- Ensure both screen recording and audio capture are blocked for protected content.
- Maintain normal audio capture behavior for non-DRM videos.
- Apply the protection consistently across streaming playback, offline downloads, and playback refresh scenarios.