### PR TITLE
feat(diagnostics): Add global playback history for production error tracing

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -49,6 +49,7 @@ import com.tpstreams.player.util.network.*
 import androidx.media3.exoplayer.analytics.AnalyticsListener
 import androidx.media3.exoplayer.DecoderReuseEvaluation
 import com.tpstreams.player.util.PlaybackHistoryManager
+import com.tpstreams.player.util.CodecManager
 
 
 
@@ -142,7 +143,16 @@ private constructor(
                 initializedTimestampMs: Long,
                 initializationDurationMs: Long
             ) {
-                debugLog("Decoder INIT - Codec: $decoderName")
+                CodecManager.onDecoderInitialized()
+                CodecManager.logCodecStatus(decoderName, "video/avc")
+            }
+
+            override fun onVideoDecoderReleased(
+                eventTime: AnalyticsListener.EventTime,
+                decoderName: String
+            ) {
+                CodecManager.onDecoderReleased()
+                debugLog("Decoder RELEASED - Codec: $decoderName")
             }
 
             override fun onVideoInputFormatChanged(

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -46,6 +46,11 @@ import com.tpstreams.player.data.AssetInfo
 import com.tpstreams.player.data.AssetRepository
 import com.tpstreams.player.util.MediaItemUtils
 import com.tpstreams.player.util.network.*
+import androidx.media3.exoplayer.analytics.AnalyticsListener
+import androidx.media3.exoplayer.DecoderReuseEvaluation
+import com.tpstreams.player.util.PlaybackHistoryManager
+
+
 
 class TPStreamsPlayer @OptIn(UnstableApi::class)
 private constructor(
@@ -62,6 +67,16 @@ private constructor(
     val downloadMetadata: Map<String, String>? = null,
     val offlineLicenseExpireTime: Long = DownloadConstants.FIFTEEN_DAYS_IN_SECONDS
 ) : Player by exoPlayer {
+
+    val playbackSessionId = (1..6)
+        .map { (('a'..'z') + ('0'..'9')).random() }
+        .joinToString("")
+
+    private fun debugLog(message: String) {
+        val fullMessage = "[$playbackSessionId] $message"
+        Log.d(DEBUG_TAG, fullMessage)
+        PlaybackHistoryManager.recordLog(fullMessage)
+    }
 
     interface Listener {
         fun onAccessTokenExpired(videoId: String, callback: (String) -> Unit)
@@ -93,6 +108,7 @@ private constructor(
                         fetchAndPrepare(org, assetId, accessToken)
                     }
                 } else {
+                    debugLog("Player PREPARE (Retry)")
                     exoPlayer.prepare()
                     exoPlayer.play()
                 }
@@ -113,6 +129,77 @@ private constructor(
         }
 
     init {
+        debugLog("Player INIT - Instance created for assetId: $assetId")
+        synchronized(TPStreamsPlayer::class.java) {
+            activePlayerCount++
+            debugLog("Active Player COUNT: $activePlayerCount")
+        }
+
+        exoPlayer.addAnalyticsListener(object : AnalyticsListener {
+            override fun onVideoDecoderInitialized(
+                eventTime: AnalyticsListener.EventTime,
+                decoderName: String,
+                initializedTimestampMs: Long,
+                initializationDurationMs: Long
+            ) {
+                debugLog("Decoder INIT - Codec: $decoderName")
+            }
+
+            override fun onVideoInputFormatChanged(
+                eventTime: AnalyticsListener.EventTime,
+                format: Format,
+                decoderReuseEvaluation: DecoderReuseEvaluation?
+            ) {
+                debugLog("Decoder Format - ${format.sampleMimeType}, Res: ${format.width}x${format.height}, Bitrate: ${format.bitrate}")
+                if (decoderReuseEvaluation != null) {
+                    val resultLabel = when (decoderReuseEvaluation.result) {
+                        DecoderReuseEvaluation.REUSE_RESULT_NO -> "NO"
+                        DecoderReuseEvaluation.REUSE_RESULT_YES_WITH_FLUSH -> "YES_WITH_FLUSH"
+                        DecoderReuseEvaluation.REUSE_RESULT_YES_WITH_RECONFIGURATION -> "YES_WITH_RECONFIGURATION"
+                        DecoderReuseEvaluation.REUSE_RESULT_YES_WITHOUT_RECONFIGURATION -> "YES_WITHOUT_RECONFIGURATION"
+                        else -> "UNKNOWN (${decoderReuseEvaluation.result})"
+                    }
+                    debugLog("Decoder RE-INIT / REPLACEMENT - Result: $resultLabel")
+                }
+            }
+
+            override fun onPlaybackStateChanged(eventTime: AnalyticsListener.EventTime, state: Int) {
+                val stateName = when (state) {
+                    Player.STATE_IDLE -> "IDLE"
+                    Player.STATE_BUFFERING -> "BUFFERING"
+                    Player.STATE_READY -> "READY"
+                    Player.STATE_ENDED -> "ENDED"
+                    else -> "UNKNOWN"
+                }
+                debugLog("Playback STATE CHANGE - $stateName")
+            }
+
+            override fun onRenderedFirstFrame(eventTime: AnalyticsListener.EventTime, output: Any, renderTimeMs: Long) {
+                debugLog("First Frame Rendered")
+            }
+
+            override fun onSurfaceSizeChanged(eventTime: AnalyticsListener.EventTime, width: Int, height: Int) {
+                debugLog("Surface SIZE CHANGED - ${width}x${height}")
+            }
+
+            override fun onMediaItemTransition(
+                eventTime: AnalyticsListener.EventTime,
+                mediaItem: MediaItem?,
+                reason: Int
+            ) {
+                if (mediaItem != null) {
+                    val transitionReason = when (reason) {
+                        Player.MEDIA_ITEM_TRANSITION_REASON_AUTO -> "AUTO"
+                        Player.MEDIA_ITEM_TRANSITION_REASON_PLAYLIST_CHANGED -> "PLAYLIST_CHANGED"
+                        Player.MEDIA_ITEM_TRANSITION_REASON_REPEAT -> "REPEAT"
+                        Player.MEDIA_ITEM_TRANSITION_REASON_SEEK -> "SEEK"
+                        else -> "UNKNOWN ($reason)"
+                    }
+                    debugLog("MediaItem TRANSITION - ${mediaItem.mediaId}, Reason: $transitionReason")
+                }
+            }
+        })
+
         Log.d("TPStreamsPlayer", "Initializing TPStreamsPlayer with assetId: $assetId")
         
         exoPlayer.addListener(object : Player.Listener {
@@ -150,6 +237,7 @@ private constructor(
                      networkRecoveryHandler.startMonitoring { retryPlayback() }
                 }
                 
+                debugLog("Player ERROR - ${error.errorCodeName}")
                 val errorPlayerId = SentryLogger.generatePlayerIdString()
                 SentryLogger.logPlaybackException(error, assetId, errorPlayerId)
                 
@@ -222,7 +310,9 @@ private constructor(
                     val audioAttributes = buildAudioAttributes(assetInfo.enableDrm)
 
                     exoPlayer.setAudioAttributes(audioAttributes, true)
+                    debugLog("MediaItem SET - ${result.mediaItem.mediaId}")
                     exoPlayer.setMediaItem(result.mediaItem)
+                    debugLog("Player PREPARE")
                     exoPlayer.prepare()
                     isPrepared = true
                 }
@@ -304,7 +394,9 @@ private constructor(
             exoPlayer.setAudioAttributes(audioAttributes, true)
             exoPlayer.clearMediaItems()
             
+            debugLog("MediaItem SET (Download) - ${mediaItem.mediaId}")
             exoPlayer.setMediaItem(mediaItem)
+            debugLog("Player PREPARE")
             exoPlayer.prepare()
             val duration = exoPlayer.duration
             if ((currentPosition > 0) && (duration == C.TIME_UNSET || currentPosition < duration)) {
@@ -369,6 +461,12 @@ private constructor(
     override fun getPlaybackState(): Int = exoPlayer.playbackState
 
     override fun release() {
+        debugLog("Surface DETACH (Player Released)")
+        debugLog("Player RELEASE - assetId: $assetId")
+        synchronized(TPStreamsPlayer::class.java) {
+            activePlayerCount--
+            debugLog("Active Player COUNT: $activePlayerCount")
+        }
         playerScope.cancel()
         exoPlayer.release()
         networkRecoveryHandler.stopMonitoring()
@@ -582,6 +680,8 @@ private constructor(
     }
 
     companion object {
+        private var activePlayerCount = 0
+        private const val DEBUG_TAG = "PLAYBACK_ERROR_DEBUG"
         private val client = OkHttpClient()
         private const val LICENSE_URL_TEMPLATE = "https://app.tpstreams.com/api/v1/%s/assets/%s/drm_license/?access_token=%s&download=%s&license_duration_seconds=%s"
 

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -681,7 +681,7 @@ private constructor(
 
     companion object {
         private var activePlayerCount = 0
-        private const val DEBUG_TAG = "PLAYBACK_ERROR_DEBUG"
+        internal const val DEBUG_TAG = "PLAYBACK_ERROR_DEBUG"
         private val client = OkHttpClient()
         private const val LICENSE_URL_TEMPLATE = "https://app.tpstreams.com/api/v1/%s/assets/%s/drm_license/?access_token=%s&download=%s&license_duration_seconds=%s"
 

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
@@ -336,7 +336,7 @@ class TPStreamsPlayerView @JvmOverloads constructor(
         val previousPlayer = getPlayer()
         if (previousPlayer is TPStreamsPlayer) {
             val message = "[${previousPlayer.playbackSessionId}] Surface DETACH"
-            Log.d("PLAYBACK_ERROR_DEBUG", message)
+            Log.d(TPStreamsPlayer.DEBUG_TAG, message)
             PlaybackHistoryManager.recordLog(message)
             previousPlayer.listener = null
             previousPlayer.onLiveStreamStatusChanged = null
@@ -348,7 +348,7 @@ class TPStreamsPlayerView @JvmOverloads constructor(
         
         if (player is TPStreamsPlayer) {
             val message = "[${player.playbackSessionId}] Surface ATTACH"
-            Log.d("PLAYBACK_ERROR_DEBUG", message)
+            Log.d(TPStreamsPlayer.DEBUG_TAG, message)
             PlaybackHistoryManager.recordLog(message)
         }
         

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
@@ -14,6 +14,7 @@ import androidx.media3.common.PlaybackException
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.ui.PlayerView
 import com.tpstreams.player.constants.PlaybackError
+import com.tpstreams.player.util.PlaybackHistoryManager
 import com.tpstreams.player.R
 
 @UnstableApi
@@ -334,6 +335,9 @@ class TPStreamsPlayerView @JvmOverloads constructor(
         // Clean up previous player
         val previousPlayer = getPlayer()
         if (previousPlayer is TPStreamsPlayer) {
+            val message = "[${previousPlayer.playbackSessionId}] Surface DETACH"
+            Log.d("PLAYBACK_ERROR_DEBUG", message)
+            PlaybackHistoryManager.recordLog(message)
             previousPlayer.listener = null
             previousPlayer.onLiveStreamStatusChanged = null
             previousPlayer.removeListener(tracksStateListener)
@@ -341,6 +345,12 @@ class TPStreamsPlayerView @JvmOverloads constructor(
         previousPlayer?.removeListener(playbackStateListener)
         
         super.setPlayer(player)
+        
+        if (player is TPStreamsPlayer) {
+            val message = "[${player.playbackSessionId}] Surface ATTACH"
+            Log.d("PLAYBACK_ERROR_DEBUG", message)
+            PlaybackHistoryManager.recordLog(message)
+        }
         
         lifecycleManager = player?.let { PlayerLifecycleManager(it) }
         registerWithLifecycle()

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/CodecManager.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/CodecManager.kt
@@ -1,0 +1,63 @@
+package com.tpstreams.player.util
+
+import android.media.MediaCodecList
+import androidx.annotation.OptIn
+import androidx.media3.common.util.Log
+import androidx.media3.common.util.UnstableApi
+import java.util.concurrent.atomic.AtomicInteger
+
+@OptIn(UnstableApi::class)
+object CodecManager {
+    private const val TAG = "CodecManager"
+    private val activeDecoderCount = AtomicInteger(0)
+
+    /**
+     * Increments the count of active decoders and returns the new count.
+     */
+    fun onDecoderInitialized() {
+        val count = activeDecoderCount.incrementAndGet()
+        Log.d(TAG, "Decoder initialized. SDK Active Decoders: $count")
+    }
+
+    /**
+     * Decrements the count of active decoders.
+     */
+    fun onDecoderReleased() {
+        val count = activeDecoderCount.decrementAndGet()
+        Log.d(TAG, "Decoder released. SDK Active Decoders: $count")
+    }
+
+    /**
+     * Returns the current number of active decoders in the SDK.
+     */
+    fun getActiveDecoderCount(): Int = activeDecoderCount.get()
+
+    /**
+     * Attempts to find the maximum supported instances for a given codec and MIME type.
+     * Note: This is an expensive system call; use only for diagnostics.
+     */
+    fun getMaxSupportedInstances(codecName: String, mimeType: String): Int {
+        return try {
+            val codecList = MediaCodecList(MediaCodecList.ALL_CODECS)
+            val info = codecList.codecInfos.find { it.name == codecName }
+            val capabilities = info?.getCapabilitiesForType(mimeType)
+            capabilities?.maxSupportedInstances ?: -1
+        } catch (e: Exception) {
+            -1
+        }
+    }
+    
+    /**
+     * Logs the current codec status.
+     */
+    fun logCodecStatus(codecName: String, mimeType: String) {
+        val max = getMaxSupportedInstances(codecName, mimeType)
+        val active = getActiveDecoderCount()
+        val capacityStr = if (max > 0) max.toString() else "Unknown"
+        
+        Log.d(TAG, "Codec Capacity Status - Codec: $codecName | Total Hardware Limit: $capacityStr | TPStreams Active: $active")
+        
+        // Also add to play history for Sentry
+        PlaybackHistoryManager.recordLog("CODEC_STATUS: $codecName, Limit: $capacityStr, Active: $active")
+    }
+}

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/PlaybackHistoryManager.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/PlaybackHistoryManager.kt
@@ -17,11 +17,13 @@ internal object PlaybackHistoryManager {
      */
     fun recordLog(message: String) {
         logHistory.addLast(message)
-        val currentCount = logCount.incrementAndGet()
+        logCount.incrementAndGet()
 
-        if (currentCount > MAX_LOG_LINES) {
+        while (logCount.get() > MAX_LOG_LINES) {
             if (logHistory.pollFirst() != null) {
                 logCount.decrementAndGet()
+            } else {
+                break
             }
         }
     }

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/PlaybackHistoryManager.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/PlaybackHistoryManager.kt
@@ -1,6 +1,7 @@
 package com.tpstreams.player.util
 
 import java.util.concurrent.ConcurrentLinkedDeque
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Singleton to manage global playback history for production debugging.
@@ -9,15 +10,19 @@ import java.util.concurrent.ConcurrentLinkedDeque
 internal object PlaybackHistoryManager {
     private const val MAX_LOG_LINES = 1000
     private val logHistory = ConcurrentLinkedDeque<String>()
+    private val logCount = AtomicInteger(0)
 
     /**
      * Records a log message in the global history.
      */
     fun recordLog(message: String) {
-        logHistory.add(message)
-        // Keep the history size within limits
-        while (logHistory.size > MAX_LOG_LINES) {
-            logHistory.pollFirst()
+        logHistory.addLast(message)
+        val currentCount = logCount.incrementAndGet()
+
+        if (currentCount > MAX_LOG_LINES) {
+            if (logHistory.pollFirst() != null) {
+                logCount.decrementAndGet()
+            }
         }
     }
 
@@ -41,5 +46,6 @@ internal object PlaybackHistoryManager {
      */
     fun clearHistory() {
         logHistory.clear()
+        logCount.set(0)
     }
 }

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/PlaybackHistoryManager.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/PlaybackHistoryManager.kt
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicInteger
  * Stores a chronological list of video events to help trace decoder/memory issues across multiple sessions.
  */
 internal object PlaybackHistoryManager {
-    private const val MAX_LOG_LINES = 1000
+    private const val MAX_LOG_LINES = 500
     private val logHistory = ConcurrentLinkedDeque<String>()
     private val logCount = AtomicInteger(0)
 

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/PlaybackHistoryManager.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/PlaybackHistoryManager.kt
@@ -1,0 +1,45 @@
+package com.tpstreams.player.util
+
+import java.util.concurrent.ConcurrentLinkedDeque
+
+/**
+ * Singleton to manage global playback history for production debugging.
+ * Stores a chronological list of video events to help trace decoder/memory issues across multiple sessions.
+ */
+internal object PlaybackHistoryManager {
+    private const val MAX_LOG_LINES = 1000
+    private val logHistory = ConcurrentLinkedDeque<String>()
+
+    /**
+     * Records a log message in the global history.
+     */
+    fun recordLog(message: String) {
+        logHistory.add(message)
+        // Keep the history size within limits
+        while (logHistory.size > MAX_LOG_LINES) {
+            logHistory.pollFirst()
+        }
+    }
+
+    /**
+     * Returns the entire history as a formatted string block.
+     * Use this when attaching to Sentry or other error reporting.
+     */
+    fun getFullHistory(): String {
+        return logHistory.joinToString("\n")
+    }
+
+    /**
+     * Returns the history as a list of strings if needed for tabular context.
+     */
+    fun getHistoryList(): List<String> {
+        return logHistory.toList()
+    }
+
+    /**
+     * Clears all history. Usually done at app level if required.
+     */
+    fun clearHistory() {
+        logHistory.clear()
+    }
+}

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/SentryLogger.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/SentryLogger.kt
@@ -2,6 +2,7 @@ package com.tpstreams.player.util
 
 import androidx.media3.common.PlaybackException
 import com.tpstreams.player.TPStreamsPlayer
+import com.tpstreams.player.util.PlaybackHistoryManager
 import io.sentry.Sentry
 
 internal object SentryLogger {
@@ -29,6 +30,10 @@ internal object SentryLogger {
                     "Asset ID" to (assetId ?: "N/A"),
                     "Player ID" to playerId
                 )
+            )
+            scope.setContext(
+                "Playback Timeline History",
+                PlaybackHistoryManager.getFullHistory()
             )
         }
     }

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/SentryLogger.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/SentryLogger.kt
@@ -1,5 +1,6 @@
 package com.tpstreams.player.util
 
+import android.util.Log
 import androidx.media3.common.PlaybackException
 import com.tpstreams.player.TPStreamsPlayer
 import com.tpstreams.player.util.PlaybackHistoryManager
@@ -31,9 +32,9 @@ internal object SentryLogger {
                     "Player ID" to playerId
                 )
             )
-            scope.setContext(
-                "Playback Timeline History",
-                PlaybackHistoryManager.getFullHistory()
+            scope.setContexts(
+                "Playback History",
+                mapOf("Timeline" to PlaybackHistoryManager.getFullHistory())
             )
         }
     }


### PR DESCRIPTION
- Introduced a session-persistent flight recorder to capture a chronological timeline of all player events across the app's lifecycle. 
- Every log (Surface attach/detach, Decoder initialization, Player life-cycle, and Active Player Count) is now stored in a 1000-line global buffer and automatically attached to Sentry reports when a PlaybackException occurs.
- This provides the necessary evidence to identify "resource leaks" from previous video sessions that lead to hardware DECODER_INIT_FAILED (4001/4003) errors in production, even when the current session appears managed.