### PR TITLE
feat(core): Add multi-provider support for TPStreams and Testpress backends

### DIFF
--- a/app/src/main/java/com/tpstreams/player/MainActivity.kt
+++ b/app/src/main/java/com/tpstreams/player/MainActivity.kt
@@ -34,7 +34,6 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         
         // Initialize SDK once
-        TPStreamsSDK.init("9q94nm")
 
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
@@ -45,18 +44,32 @@ class MainActivity : AppCompatActivity() {
         updateDownloadsButtonVisibility()
 
         binding.btnDrmVideo.setOnClickListener {
+            TPStreamsSDK.init("9q94nm")
             startPlayer("42h2tZ5fmNf", "9327e2d0-fa13-4288-902d-840f32cd0eed")
         }
 
         binding.btnNonDrmVideo.setOnClickListener {
+            TPStreamsSDK.init("9q94nm")
             startPlayer("4Zs4MNd5Ksj", "c4f36a4f-3859-4b24-aca8-189b7e8cfeb0")
         }
 
+        binding.btnTestpressDrm.setOnClickListener {
+            TPStreamsSDK.init("lmsdemo", TPStreamsSDK.Provider.TestPress)
+            startPlayer("ATJfRdHIUC9", "a4c04ca8-9c0e-4c9c-a889-bd3bf8ea586a")
+        }
+
+        binding.btnTestpressNonDrm.setOnClickListener {
+            TPStreamsSDK.init("lmsdemo", TPStreamsSDK.Provider.TestPress)
+            startPlayer("z1TLpfuZzXh", "5c49285b-0557-4cef-b214-66034d0b77c3")
+        }
+
         binding.btnDownloadDrm720.setOnClickListener {
+            TPStreamsSDK.init("9q94nm")
             downloadClient.startDownload(this, "7xbZeQzR36h", "3d9838f3-db51-4fc3-8472-075ab5e40b64", "480p")
         }
 
         binding.btnDownloadDrmSelect.setOnClickListener {
+            TPStreamsSDK.init("9q94nm")
             downloadClient.startDownload(this, "37jGF3sXcHh", "df9d3cd8-cec5-41db-bfae-748233d66313")
         }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -52,6 +52,22 @@
                 android:padding="16dp"
                 android:text="Non-DRM Video" />
 
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btn_testpress_drm"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:padding="16dp"
+                android:text="Testpress DRM Video" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btn_testpress_non_drm"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:padding="16dp"
+                android:text="Testpress Non-DRM Video" />
+
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/openspec/changes/add-testpress-provider-support/.openspec.yaml
+++ b/openspec/changes/add-testpress-provider-support/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-10

--- a/openspec/changes/add-testpress-provider-support/design.md
+++ b/openspec/changes/add-testpress-provider-support/design.md
@@ -1,0 +1,77 @@
+## Context
+
+The SDK currently couples provider assumptions (TPStreams URLs and payload shape) directly inside playback and download paths. This creates repeated hardcoded endpoint logic and prevents Testpress from using the same codepath. We need to add multi-provider capability while preserving existing public behavior and avoiding large-scale refactoring.
+
+Constraints:
+- Existing TPStreams integrations using `TPStreamsSDK.init(orgId)` must keep working.
+- Playback and download UI/control flows should not be redesigned in this change.
+- Risk should be concentrated in metadata/endpoint seams, not player lifecycle code.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add provider selection at SDK initialization with a backward-compatible default.
+- Keep provider-specific endpoint URL construction and response parsing together in clear API service classes.
+- Keep downstream playback/download consumers operating on the existing `AssetInfo` model.
+- Minimize code churn outside network/parsing integration points.
+
+**Non-Goals:**
+- Replacing the current player architecture or introducing full clean-architecture layering everywhere.
+- Redesigning `TPStreamsPlayer` UI/control APIs.
+- Introducing new public domain models for playback metadata.
+- Changing offline storage format or download state management behavior.
+
+## Decisions
+
+1. Add provider-aware SDK config with compatibility default
+- Decision: Add a `Provider` enum to the `com.tpstreams.player` package and update `TPStreamsSDK.init(orgId, provider = Provider.TPStreams)`.
+- Why: Enables Testpress support with a clean, typesafe API while preserving fallback behavior for existing TPStreams callers without requiring them to handle internal `ApiService` classes.
+- Alternatives considered:
+  - Replace existing init signature only: rejected because it is a breaking API change.
+  - Infer provider from org format: rejected as fragile and implicit.
+
+2. Use backend API service classes
+- Decision: Introduce `BaseApiService` with two concrete implementations: `TPStreamsApiService` and `TestPressApiService`.
+- Why: Keeps endpoint construction and parsing behavior for each backend in one place, while avoiding extra helper abstractions.
+- Alternatives considered:
+  - Endpoint builder + parser interface split: rejected as unnecessary complexity for this scope.
+  - One giant conditional parser in repository: rejected for readability and maintainability.
+
+4. Preserve `AssetInfo` as unified handoff model
+- Decision: Keep existing `AssetInfo` contract for now and map both providers into it.
+- Why: Avoids touching broad downstream surfaces in player/download modules.
+- Alternatives considered:
+  - Introduce a new canonical domain model now: rejected to avoid major refactor.
+
+5. Migrate URL usage sites to active API service
+- Decision: Update `AssetRepository`, `MediaItemUtils`, `TPStreamsPlayer` token checks/license templates, and `DownloadClient` dependencies to use `TPStreamsSDK.apiService`.
+- Why: Ensures behavior consistency across playback and downloads.
+- Alternatives considered:
+  - Update repository only: rejected because DRM/token checks would remain TPStreams-only.
+
+## Risks / Trade-offs
+
+- [Risk] Provider edge-case mismatch in live stream status mapping (especially Testpress) → Mitigation: parser-level tests for livestream, DRM/non-DRM, and fallback branches.
+- [Risk] Silent regressions for existing TPStreams flows due to endpoint migration → Mitigation: keep TPStreams as default provider and add API service URL/parser unit tests.
+- [Risk] Incomplete migration leaving some hardcoded TPStreams URLs → Mitigation: explicit grep checks and a migration checklist for all known call sites.
+- [Trade-off] We keep `AssetInfo` and JSONObject-based parsing for minimal churn → Mitigation: document this as intentional and defer typed network models to a later cleanup change.
+
+## Migration Plan
+
+1. Add provider config storage and backward-compatible init overload in SDK config.
+2. Add `BaseApiService`, `TPStreamsApiService`, and `TestPressApiService`.
+3. Wire repository to active API service endpoint + parsing behavior.
+4. Update media item DRM URL and player token-validation/license URL paths to active API service.
+5. Update download flow to consume provider-aware behavior consistently.
+6. Add focused tests for URL generation and parser behavior.
+7. Validate with both provider samples in the example app.
+
+Rollback strategy:
+- Revert to TPStreams-only behavior by forcing default provider branch and restoring old direct TPStreams URL templates.
+- Since public default init remains unchanged, rollback risk is low and localized.
+
+## Open Questions
+
+- Should Testpress DRM license requests include any provider-specific headers in addition to query token? (Current implementation keeps query-token-only parity.)
+- Do we need explicit provider tagging in Sentry logs for this SDK (parity with old SDK diagnostics)?
+- For Testpress live-stream completion, should recorded playback fallback behavior exactly mirror old SDK wording/errors or keep current SDK error text?

--- a/openspec/changes/add-testpress-provider-support/proposal.md
+++ b/openspec/changes/add-testpress-provider-support/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The current SDK is hard-wired to TPStreams endpoints and payload assumptions, which prevents using the same player stack for Testpress-backed content. We need dual backend support now so both products can use one SDK without duplicating player logic.
+
+## What Changes
+
+- Add provider-aware SDK initialization while preserving existing `TPStreamsSDK.init(orgId)` behavior for backward compatibility.
+- Add backend API service classes (`BaseApiService`, `TPStreamsApiService`, `TestPressApiService`) that each own endpoint URL construction and response parsing.
+- Route data retrieval and media preparation flows through provider-aware endpoint/parsing layers without major refactoring of player UI or controls.
+- Keep `AssetInfo` as the unified output model for playback and download flows (moved under network model package).
+
+## Capabilities
+
+### New Capabilities
+- `multi-provider-backend-support`: Allow the SDK to fetch playback metadata and DRM/token endpoints from either TPStreams or Testpress using provider-aware routing and parsing.
+
+### Modified Capabilities
+- None.
+
+## Impact
+
+- Affected code:
+  - SDK initialization/config (`TPStreamsSDK`)
+  - Asset metadata fetching/parsing (`data/AssetRepository` and backend API service classes)
+  - Media item and DRM URL construction (`util/MediaItemUtils`)
+  - Token validation and URL usage in player/download paths (`TPStreamsPlayer`, `download/DownloadClient`)
+- API impact:
+  - Adds an overload/init path with provider selection.
+  - Existing TPStreams-only initialization remains supported.
+- Dependencies:
+  - No new external runtime dependency is required.
+- Systems:
+  - Playback and download flows become provider-aware while retaining current TPStreams behavior as default.

--- a/openspec/changes/add-testpress-provider-support/specs/multi-provider-backend-support/spec.md
+++ b/openspec/changes/add-testpress-provider-support/specs/multi-provider-backend-support/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: SDK initialization SHALL support explicit provider selection
+The SDK SHALL allow callers to initialize configuration with both provider and organization code, while preserving the existing initialization method that accepts only organization code.
+
+#### Scenario: Backward-compatible TPStreams initialization
+- **WHEN** the caller initializes the SDK with organization code only
+- **THEN** the SDK MUST configure provider as TPStreams by default and remain usable without API changes
+
+#### Scenario: Explicit Testpress initialization
+- **WHEN** the caller initializes the SDK with provider `TestPress` and a valid organization code
+- **THEN** the SDK MUST store and use that provider for metadata, DRM, and token-validation endpoints
+
+### Requirement: Endpoint resolution SHALL be provider-aware and centralized
+The SDK SHALL construct asset metadata, DRM license, and token-validation URLs through a centralized provider-aware endpoint resolver.
+
+#### Scenario: TPStreams endpoint resolution
+- **WHEN** provider is TPStreams and the SDK needs an asset metadata endpoint
+- **THEN** the resolver MUST produce the TPStreams API URL format with organization code, asset id, and access token
+
+#### Scenario: Testpress endpoint resolution
+- **WHEN** provider is TestPress and the SDK needs an asset metadata endpoint
+- **THEN** the resolver MUST produce the Testpress API URL format with organization code, asset id, and access token
+
+### Requirement: Metadata parsing SHALL support TPStreams and Testpress payloads
+The SDK SHALL parse provider-specific metadata responses through provider-specific parsers and return a unified playback metadata object for downstream consumers.
+
+#### Scenario: TPStreams payload parsing
+- **WHEN** a TPStreams asset metadata response is received
+- **THEN** the TPStreams parser MUST map playback URL, DRM flag, thumbnail, track metadata, live-stream state, and duration into the unified model
+
+#### Scenario: Testpress payload parsing
+- **WHEN** a Testpress asset metadata response is received
+- **THEN** the Testpress parser MUST map playback URL, DRM flag, thumbnail, live-stream state, and duration into the unified model
+
+### Requirement: Playback and download flows SHALL consume provider-aware endpoints without behavioral regression
+Playback and download internals SHALL use provider-aware endpoint and parser outputs without requiring UI or control-layer API changes.
+
+#### Scenario: DRM media item preparation
+- **WHEN** DRM is enabled for an asset
+- **THEN** the media item builder MUST use provider-aware DRM license endpoint generation and preserve existing DRM playback behavior
+
+#### Scenario: Download/token validation path
+- **WHEN** download start or access-token validation is triggered
+- **THEN** the SDK MUST use provider-aware endpoint construction and preserve existing TPStreams behavior when provider is not explicitly set

--- a/openspec/changes/add-testpress-provider-support/tasks.md
+++ b/openspec/changes/add-testpress-provider-support/tasks.md
@@ -1,0 +1,25 @@
+## 1. SDK Provider Configuration
+
+- [x] 1.1 Extend `TPStreamsSDK` with stored API service and org configuration.
+- [x] 1.2 Keep `TPStreamsSDK.init(orgId)` backward compatible by defaulting to `TPStreamsApiService`.
+- [x] 1.3 Add explicit initialization overload that accepts `BaseApiService` and org code.
+
+## 2. API Service and Parsing Core
+
+- [x] 2.1 Add `BaseApiService` with endpoint methods and `parseAsset`.
+- [x] 2.2 Implement `TPStreamsApiService` with TPStreams endpoint and parsing logic.
+- [x] 2.3 Implement `TestPressApiService` with Testpress endpoint and parsing logic based on old SDK response fields.
+- [x] 2.4 Move `AssetInfo` to network model package and update imports.
+
+## 3. Integrate Provider-Aware Flow
+
+- [x] 3.1 Update `AssetRepository` to call `TPStreamsSDK.apiService` for endpoint and parsing.
+- [x] 3.2 Update `MediaItemUtils` DRM URL construction to use `TPStreamsSDK.apiService`.
+- [x] 3.3 Update token validation and license URL paths in `TPStreamsPlayer` to use `TPStreamsSDK.apiService`.
+- [x] 3.4 Update `DownloadClient` integration points to use provider-aware repository behavior.
+
+## 4. Validation and Compatibility Checks
+
+- [x] 4.1 Add API service unit tests for URL outputs for both TPStreams and Testpress.
+- [x] 4.2 Run regression checks to confirm TPStreams default behavior is unchanged when provider is not explicitly set.
+- [x] 4.4 Verify no remaining hardcoded TPStreams endpoint strings exist in provider-sensitive paths.

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -292,8 +292,8 @@ private constructor(
             if (playFromDownload(assetId)) return@launch
 
             AssetRepository.fetchAssetInfo(assetId, accessToken, object : AssetRepository.AssetCallback {
-                override fun onSuccess(assetInfo: AssetInfo, title: String) {
-                    preparePlayer(assetInfo, title, assetId, accessToken)
+                override fun onSuccess(assetInfo: AssetInfo) {
+                    preparePlayer(assetInfo, assetId, accessToken)
                 }
 
                 override fun onError(error: PlaybackError, message: String) {
@@ -308,12 +308,12 @@ private constructor(
     }
 
     @OptIn(UnstableApi::class)
-    private fun preparePlayer(assetInfo: AssetInfo, title: String, assetId: String, accessToken: String) {
+    private fun preparePlayer(assetInfo: AssetInfo, assetId: String, accessToken: String) {
         val orgId = TPStreamsSDK.requireOrgId()
         _isLiveStream = assetInfo.isLiveStream
         onLiveStreamStatusChanged?.invoke(_isLiveStream)
 
-        val result = MediaItemUtils.buildMediaItem(assetInfo, title, orgId, assetId, accessToken)
+        val result = MediaItemUtils.buildMediaItem(assetInfo, assetInfo.title, orgId, assetId, accessToken)
         setSubtitleMetadata(result.subtitleMetadata)
 
         playerScope.launch(Dispatchers.Main) {

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -42,7 +42,7 @@ import com.tpstreams.player.constants.getErrorMessage
 import com.tpstreams.player.constants.LiveStreamNotStartedException
 import com.tpstreams.player.constants.LiveStreamEndedException
 import com.tpstreams.player.constants.toPlaybackError
-import com.tpstreams.player.data.AssetInfo
+import com.tpstreams.player.data.network.model.AssetInfo
 import com.tpstreams.player.data.AssetRepository
 import com.tpstreams.player.util.MediaItemUtils
 import com.tpstreams.player.util.network.*
@@ -106,7 +106,7 @@ private constructor(
                     val org = TPStreamsSDK.orgId
                     if (org != null) {
                         Log.d("TPStreamsPlayer", "Retrying initial fetchAndPrepare")
-                        fetchAndPrepare(org, assetId, accessToken)
+                        fetchAndPrepare(assetId, accessToken)
                     }
                 } else {
                     debugLog("Player PREPARE (Retry)")
@@ -267,9 +267,8 @@ private constructor(
             }
         })
 
-        val org = TPStreamsSDK.orgId
-            ?: throw IllegalStateException("TPStreamsSDK.init(orgId) must be called before using the player.")
-        fetchAndPrepare(org, assetId, accessToken)
+        TPStreamsSDK.requireOrgId()
+        fetchAndPrepare(assetId, accessToken)
     }
 
     private fun enableDefaultCaptions() {
@@ -288,13 +287,13 @@ private constructor(
                 cause is MediaCodec.CryptoException
     }
 
-    private fun fetchAndPrepare(orgId: String, assetId: String, accessToken: String) {
+    private fun fetchAndPrepare(assetId: String, accessToken: String) {
         CoroutineScope(Dispatchers.IO).launch {
             if (playFromDownload(assetId)) return@launch
 
-            AssetRepository.fetchAssetInfo(orgId, assetId, accessToken, object : AssetRepository.AssetCallback {
+            AssetRepository.fetchAssetInfo(assetId, accessToken, object : AssetRepository.AssetCallback {
                 override fun onSuccess(assetInfo: AssetInfo, title: String) {
-                    preparePlayer(assetInfo, title, orgId, assetId, accessToken)
+                    preparePlayer(assetInfo, title, assetId, accessToken)
                 }
 
                 override fun onError(error: PlaybackError, message: String) {
@@ -309,7 +308,8 @@ private constructor(
     }
 
     @OptIn(UnstableApi::class)
-    private fun preparePlayer(assetInfo: AssetInfo, title: String, orgId: String, assetId: String, accessToken: String) {
+    private fun preparePlayer(assetInfo: AssetInfo, title: String, assetId: String, accessToken: String) {
+        val orgId = TPStreamsSDK.requireOrgId()
         _isLiveStream = assetInfo.isLiveStream
         onLiveStreamStatusChanged?.invoke(_isLiveStream)
 
@@ -649,7 +649,7 @@ private constructor(
             
             CoroutineScope(Dispatchers.IO).launch {
                 try {
-                    val assetApiUrl = "https://app.tpstreams.com/api/v1/$orgId/assets/$assetId/?access_token=$accessToken"
+                    val assetApiUrl = TPStreamsSDK.apiService.tokenValidationUrl(orgId, assetId, accessToken)
                     val request = Request.Builder()
                         .url(assetApiUrl)
                         .head()
@@ -693,7 +693,6 @@ private constructor(
         private var activePlayerCount = 0
         internal const val DEBUG_TAG = "PLAYBACK_ERROR_DEBUG"
         private val client = OkHttpClient()
-        private const val LICENSE_URL_TEMPLATE = "https://app.tpstreams.com/api/v1/%s/assets/%s/drm_license/?access_token=%s&download=%s&license_duration_seconds=%s"
 
 
 
@@ -769,12 +768,12 @@ private constructor(
                         if (newToken.isNotEmpty()) {
                             Log.d("TPStreamsPlayer", "Received fresh token")
                             TPStreamsSDK.orgId?.let {
-                                val licenseUrl = LICENSE_URL_TEMPLATE.format(
-                                    it,
-                                    assetId,
-                                    newToken,
-                                    "true",
-                                    offlineLicenseExpireTime.toString()
+                                val licenseUrl = TPStreamsSDK.apiService.drmLicenseUrl(
+                                    orgId = it,
+                                    assetId = assetId,
+                                    accessToken = newToken,
+                                    download = true,
+                                    licenseDurationSeconds = offlineLicenseExpireTime
                                 )
                                 Log.d("TPStreamsPlayer", "Built license URL with fresh token: $licenseUrl")
                                 callback(licenseUrl)
@@ -793,12 +792,12 @@ private constructor(
                 } else {
                     Log.d("TPStreamsPlayer", "Token is valid, using current token")
                     TPStreamsSDK.orgId?.let {
-                        val licenseUrl = LICENSE_URL_TEMPLATE.format(
-                            it,
-                            assetId,
-                            accessToken,
-                            "true",
-                            offlineLicenseExpireTime.toString()
+                        val licenseUrl = TPStreamsSDK.apiService.drmLicenseUrl(
+                            orgId = it,
+                            assetId = assetId,
+                            accessToken = accessToken,
+                            download = true,
+                            licenseDurationSeconds = offlineLicenseExpireTime
                         )
                         Log.d("TPStreamsPlayer", "Built license URL with current token: $licenseUrl")
                         callback(licenseUrl)
@@ -811,5 +810,3 @@ private constructor(
         }
     }
 }
-
-

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsSDK.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsSDK.kt
@@ -16,7 +16,7 @@ object TPStreamsSDK {
 
     internal var orgId: String?
         get() = _orgCode
-        set(value) {
+        private set(value) {
             _orgCode = value
         }
 

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsSDK.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsSDK.kt
@@ -1,10 +1,39 @@
 package com.tpstreams.player
 
+import com.tpstreams.player.data.network.api.BaseApiService
+import com.tpstreams.player.data.network.api.TPStreamsApiService
+import com.tpstreams.player.data.network.api.TestPressApiService
+
 object TPStreamsSDK {
-    internal var orgId: String? = null
+
+    enum class Provider {
+        TPStreams,
+        TestPress
+    }
+
+    internal lateinit var apiService: BaseApiService
+    private var _orgCode: String? = null
+
+    internal var orgId: String?
+        get() = _orgCode
+        set(value) {
+            _orgCode = value
+        }
 
     @JvmStatic
-    fun init(orgId: String) {
-        this.orgId = orgId
+    @JvmOverloads
+    fun init(orgId: String, provider: Provider = Provider.TPStreams) {
+        require(orgId.isNotBlank()) { "orgId cannot be empty." }
+        apiService = when (provider) {
+            Provider.TPStreams -> TPStreamsApiService()
+            Provider.TestPress -> TestPressApiService()
+        }
+        _orgCode = orgId
     }
-} 
+
+    internal fun requireOrgId(): String {
+        return _orgCode ?: throw IllegalStateException(
+            "TPStreamsSDK.init(orgId) or TPStreamsSDK.init(orgId, Provider) must be called first."
+        )
+    }
+}

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/data/AssetRepository.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/data/AssetRepository.kt
@@ -1,11 +1,10 @@
 package com.tpstreams.player.data
 
-import android.util.Log
-import com.tpstreams.player.constants.LiveStreamEndedException
-import com.tpstreams.player.constants.LiveStreamNotStartedException
+import com.tpstreams.player.TPStreamsSDK
 import com.tpstreams.player.constants.PlaybackError
-import com.tpstreams.player.constants.toPlaybackError
 import com.tpstreams.player.constants.getErrorMessage
+import com.tpstreams.player.constants.toPlaybackError
+import com.tpstreams.player.data.network.model.AssetInfo
 import com.tpstreams.player.util.SentryLogger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -15,11 +14,10 @@ import okhttp3.Request
 import org.json.JSONObject
 
 /**
- * Repository for fetching and parsing asset metadata from the TPStreams API.
+ * Repository for fetching and parsing asset metadata from configured backend providers.
  */
 object AssetRepository {
     private val client = OkHttpClient()
-    private const val BASE_URL = "https://app.tpstreams.com/api/v1"
 
     interface AssetCallback {
         fun onSuccess(assetInfo: AssetInfo, title: String)
@@ -34,7 +32,8 @@ object AssetRepository {
     ) {
         CoroutineScope(Dispatchers.IO).launch {
             try {
-                val assetApiUrl = "$BASE_URL/$orgId/assets/$assetId/?access_token=$accessToken"
+                val apiService = TPStreamsSDK.apiService
+                val assetApiUrl = apiService.assetInfoUrl(orgId, assetId, accessToken)
                 val request = Request.Builder().url(assetApiUrl).build()
                 val response = client.newCall(request).execute()
 
@@ -52,7 +51,7 @@ object AssetRepository {
 
                 val json = JSONObject(body)
                 val title = json.optString("title", "Undefined")
-                val assetInfo = parseAssetInfo(json)
+                val assetInfo = apiService.parseAsset(json)
 
                 CoroutineScope(Dispatchers.Main).launch {
                     callback.onSuccess(assetInfo, title)
@@ -61,6 +60,14 @@ object AssetRepository {
                 handleException(assetId, e, callback)
             }
         }
+    }
+
+    fun fetchAssetInfo(
+        assetId: String,
+        accessToken: String,
+        callback: AssetCallback
+    ) {
+        fetchAssetInfo(TPStreamsSDK.requireOrgId(), assetId, accessToken, callback)
     }
 
     private fun handleApiError(assetId: String, code: Int, callback: AssetCallback) {
@@ -90,68 +97,4 @@ object AssetRepository {
             callback.onError(errorType, errorMessage)
         }
     }
-
-    private fun parseAssetInfo(json: JSONObject): AssetInfo {
-        val assetType = json.optString("type", "video")
-        val isLiveStream = assetType == "livestream"
-
-        return if (isLiveStream && json.has("live_stream") && !json.isNull("live_stream")) {
-            parseLiveStreamAssetInfo(json)
-        } else {
-            parseVideoAssetInfo(json)
-        }
-    }
-
-    private fun parseLiveStreamAssetInfo(json: JSONObject): AssetInfo {
-        val liveStreamObj = json.getJSONObject("live_stream")
-        val liveStreamStatus = liveStreamObj.optString("status", "")
-
-        return when (liveStreamStatus.uppercase(java.util.Locale.ROOT)) {
-            "NOT STARTED" -> throw LiveStreamNotStartedException("Live stream will begin soon")
-            "COMPLETED" -> {
-                if (json.has("video") && !json.isNull("video")) {
-                    val videoObj = json.getJSONObject("video")
-                    val videoStatus = videoObj.optString("status", "")
-
-                    if (videoStatus.equals("Completed", ignoreCase = true)) {
-                        val enableDrm = videoObj.optBoolean("enable_drm", false)
-                        val mediaUrl = if (enableDrm) {
-                            videoObj.optString("dash_url")
-                        } else {
-                            videoObj.optString("playback_url")
-                        }
-                        val thumbnailUrl = videoObj.optJSONArray("thumbnails")?.optString(0) ?: ""
-                        AssetInfo(mediaUrl, enableDrm, thumbnailUrl, videoObj, isLiveStream = false, durationSeconds = videoObj.optDouble("duration", 0.0))
-                    } else {
-                        throw LiveStreamEndedException("Live stream has ended")
-                    }
-                } else {
-                    throw LiveStreamEndedException("Live stream has ended")
-                }
-            }
-            else -> {
-                val enableDrm = liveStreamObj.optBoolean("enable_drm", false)
-                val mediaUrl = if (enableDrm) {
-                    liveStreamObj.optString("dash_url")
-                } else {
-                    liveStreamObj.optString("hls_url")
-                }
-                AssetInfo(mediaUrl, enableDrm, "", null, isLiveStream = true, durationSeconds = liveStreamObj.optDouble("duration", 0.0))
-            }
-        }
-    }
-
-    private fun parseVideoAssetInfo(json: JSONObject): AssetInfo {
-        val videoObj = json.getJSONObject("video")
-        val enableDrm = videoObj.optBoolean("enable_drm", false)
-        val mediaUrl = if (enableDrm) {
-            videoObj.optString("dash_url")
-        } else {
-            videoObj.optString("playback_url")
-        }
-        val thumbnailUrl = videoObj.optJSONArray("thumbnails")?.optString(0) ?: ""
-        val duration = videoObj.optDouble("duration", 0.0)
-        return AssetInfo(mediaUrl, enableDrm, thumbnailUrl, videoObj, isLiveStream = false, durationSeconds = duration)
-    }
-
 }

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/data/AssetRepository.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/data/AssetRepository.kt
@@ -20,7 +20,7 @@ object AssetRepository {
     private val client = OkHttpClient()
 
     interface AssetCallback {
-        fun onSuccess(assetInfo: AssetInfo, title: String)
+        fun onSuccess(assetInfo: AssetInfo)
         fun onError(error: PlaybackError, message: String)
     }
 
@@ -30,9 +30,10 @@ object AssetRepository {
         accessToken: String,
         callback: AssetCallback
     ) {
+        TPStreamsSDK.requireOrgId()
+        val apiService = TPStreamsSDK.apiService
         CoroutineScope(Dispatchers.IO).launch {
             try {
-                val apiService = TPStreamsSDK.apiService
                 val assetApiUrl = apiService.assetInfoUrl(orgId, assetId, accessToken)
                 val request = Request.Builder().url(assetApiUrl).build()
                 val response = client.newCall(request).execute()
@@ -50,11 +51,10 @@ object AssetRepository {
                 }
 
                 val json = JSONObject(body)
-                val title = json.optString("title", "Undefined")
                 val assetInfo = apiService.parseAsset(json)
 
                 CoroutineScope(Dispatchers.Main).launch {
-                    callback.onSuccess(assetInfo, title)
+                    callback.onSuccess(assetInfo)
                 }
             } catch (e: Exception) {
                 handleException(assetId, e, callback)

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/api/BaseApiService.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/api/BaseApiService.kt
@@ -1,0 +1,22 @@
+package com.tpstreams.player.data.network.api
+
+import com.tpstreams.player.data.network.model.AssetInfo
+import org.json.JSONObject
+
+abstract class BaseApiService {
+    abstract fun assetInfoUrl(orgId: String, assetId: String, accessToken: String): String
+
+    abstract fun drmLicenseUrl(
+        orgId: String,
+        assetId: String,
+        accessToken: String,
+        download: Boolean = false,
+        licenseDurationSeconds: Long? = null
+    ): String
+
+    open fun tokenValidationUrl(orgId: String, assetId: String, accessToken: String): String {
+        return assetInfoUrl(orgId, assetId, accessToken)
+    }
+
+    abstract fun parseAsset(json: JSONObject): AssetInfo
+}

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/api/TPStreamsApiService.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/api/TPStreamsApiService.kt
@@ -25,16 +25,17 @@ class TPStreamsApiService : BaseApiService() {
     }
 
     override fun parseAsset(json: JSONObject): AssetInfo {
+        val title = json.optString("title", "Undefined")
         val assetType = json.optString("type", "video")
         val isLiveStream = assetType == "livestream"
         return if (isLiveStream && json.has("live_stream") && !json.isNull("live_stream")) {
-            parseLiveStreamAssetInfo(json)
+            parseLiveStreamAssetInfo(json, title)
         } else {
-            parseVideoAssetInfo(json)
+            parseVideoAssetInfo(json, title)
         }
     }
 
-    private fun parseLiveStreamAssetInfo(json: JSONObject): AssetInfo {
+    private fun parseLiveStreamAssetInfo(json: JSONObject, title: String): AssetInfo {
         val liveStreamObj = json.getJSONObject("live_stream")
         val liveStreamStatus = liveStreamObj.optString("status", "")
 
@@ -53,7 +54,8 @@ class TPStreamsApiService : BaseApiService() {
                             thumbnailUrl = getThumbnail(videoObj),
                             videoObj = videoObj,
                             isLiveStream = false,
-                            durationSeconds = videoObj.optDouble("duration", 0.0)
+                            durationSeconds = videoObj.optDouble("duration", 0.0),
+                            title = title
                         )
                     } else {
                         throw LiveStreamEndedException("Live stream has ended")
@@ -76,13 +78,14 @@ class TPStreamsApiService : BaseApiService() {
                     thumbnailUrl = "",
                     videoObj = null,
                     isLiveStream = true,
-                    durationSeconds = liveStreamObj.optDouble("duration", 0.0)
+                    durationSeconds = liveStreamObj.optDouble("duration", 0.0),
+                    title = title
                 )
             }
         }
     }
 
-    private fun parseVideoAssetInfo(json: JSONObject): AssetInfo {
+    private fun parseVideoAssetInfo(json: JSONObject, title: String): AssetInfo {
         val videoObj = json.getJSONObject("video")
         val enableDrm = videoObj.optBoolean("enable_drm", false)
         return AssetInfo(
@@ -91,7 +94,8 @@ class TPStreamsApiService : BaseApiService() {
             thumbnailUrl = getThumbnail(videoObj),
             videoObj = videoObj,
             isLiveStream = false,
-            durationSeconds = videoObj.optDouble("duration", 0.0)
+            durationSeconds = videoObj.optDouble("duration", 0.0),
+            title = title
         )
     }
 
@@ -101,11 +105,12 @@ class TPStreamsApiService : BaseApiService() {
             ?.optJSONObject("h265")
 
         if (h265OutputUrl != null) {
-            return if (enableDrm) {
+            val h265Url = if (enableDrm) {
                 h265OutputUrl.optString("dash_url")
             } else {
                 h265OutputUrl.optString("hls_url")
             }
+            if (h265Url.isNotEmpty()) return h265Url
         }
 
         return if (enableDrm) {

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/api/TPStreamsApiService.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/api/TPStreamsApiService.kt
@@ -1,0 +1,122 @@
+package com.tpstreams.player.data.network.api
+
+import com.tpstreams.player.constants.LiveStreamEndedException
+import com.tpstreams.player.constants.LiveStreamNotStartedException
+import com.tpstreams.player.data.network.model.AssetInfo
+import org.json.JSONObject
+import java.util.Locale
+
+class TPStreamsApiService : BaseApiService() {
+    override fun assetInfoUrl(orgId: String, assetId: String, accessToken: String): String {
+        return "https://app.tpstreams.com/api/v1/$orgId/assets/$assetId/?access_token=$accessToken"
+    }
+
+    override fun drmLicenseUrl(
+        orgId: String,
+        assetId: String,
+        accessToken: String,
+        download: Boolean,
+        licenseDurationSeconds: Long?
+    ): String {
+        val baseUrl = "https://app.tpstreams.com/api/v1/$orgId/assets/$assetId/drm_license/?access_token=$accessToken"
+        if (!download) return baseUrl
+        val duration = licenseDurationSeconds ?: 0L
+        return "$baseUrl&download=true&license_duration_seconds=$duration"
+    }
+
+    override fun parseAsset(json: JSONObject): AssetInfo {
+        val assetType = json.optString("type", "video")
+        val isLiveStream = assetType == "livestream"
+        return if (isLiveStream && json.has("live_stream") && !json.isNull("live_stream")) {
+            parseLiveStreamAssetInfo(json)
+        } else {
+            parseVideoAssetInfo(json)
+        }
+    }
+
+    private fun parseLiveStreamAssetInfo(json: JSONObject): AssetInfo {
+        val liveStreamObj = json.getJSONObject("live_stream")
+        val liveStreamStatus = liveStreamObj.optString("status", "")
+
+        return when (liveStreamStatus.uppercase(Locale.ROOT)) {
+            "NOT STARTED" -> throw LiveStreamNotStartedException("Live stream will begin soon")
+            "COMPLETED" -> {
+                if (json.has("video") && !json.isNull("video")) {
+                    val videoObj = json.getJSONObject("video")
+                    val videoStatus = videoObj.optString("status", "")
+
+                    if (videoStatus.equals("Completed", ignoreCase = true)) {
+                        val enableDrm = videoObj.optBoolean("enable_drm", false)
+                        AssetInfo(
+                            mediaUrl = getVideoPlaybackUrl(videoObj, enableDrm),
+                            enableDrm = enableDrm,
+                            thumbnailUrl = getThumbnail(videoObj),
+                            videoObj = videoObj,
+                            isLiveStream = false,
+                            durationSeconds = videoObj.optDouble("duration", 0.0)
+                        )
+                    } else {
+                        throw LiveStreamEndedException("Live stream has ended")
+                    }
+                } else {
+                    throw LiveStreamEndedException("Live stream has ended")
+                }
+            }
+
+            else -> {
+                val enableDrm = liveStreamObj.optBoolean("enable_drm", false)
+                val mediaUrl = if (enableDrm) {
+                    liveStreamObj.optString("dash_url")
+                } else {
+                    liveStreamObj.optString("hls_url")
+                }
+                AssetInfo(
+                    mediaUrl = mediaUrl,
+                    enableDrm = enableDrm,
+                    thumbnailUrl = "",
+                    videoObj = null,
+                    isLiveStream = true,
+                    durationSeconds = liveStreamObj.optDouble("duration", 0.0)
+                )
+            }
+        }
+    }
+
+    private fun parseVideoAssetInfo(json: JSONObject): AssetInfo {
+        val videoObj = json.getJSONObject("video")
+        val enableDrm = videoObj.optBoolean("enable_drm", false)
+        return AssetInfo(
+            mediaUrl = getVideoPlaybackUrl(videoObj, enableDrm),
+            enableDrm = enableDrm,
+            thumbnailUrl = getThumbnail(videoObj),
+            videoObj = videoObj,
+            isLiveStream = false,
+            durationSeconds = videoObj.optDouble("duration", 0.0)
+        )
+    }
+
+    private fun getVideoPlaybackUrl(videoObj: JSONObject, enableDrm: Boolean): String {
+        val h265OutputUrl = videoObj
+            .optJSONObject("output_urls")
+            ?.optJSONObject("h265")
+
+        if (h265OutputUrl != null) {
+            return if (enableDrm) {
+                h265OutputUrl.optString("dash_url")
+            } else {
+                h265OutputUrl.optString("hls_url")
+            }
+        }
+
+        return if (enableDrm) {
+            videoObj.optString("dash_url")
+        } else {
+            videoObj.optString("playback_url")
+        }
+    }
+
+    private fun getThumbnail(videoObj: JSONObject): String {
+        return videoObj.optString("preview_thumbnail_url")
+            .ifEmpty { videoObj.optJSONArray("thumbnails")?.optString(0) ?: "" }
+    }
+}

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/api/TestPressApiService.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/api/TestPressApiService.kt
@@ -22,17 +22,18 @@ class TestPressApiService : BaseApiService() {
     }
 
     override fun parseAsset(json: JSONObject): AssetInfo {
+        val title = json.optString("title").ifEmpty { json.optString("name", "Undefined") }
         val contentType = json.optString("content_type", "video")
         val isLiveStream = contentType == "livestream"
 
         return if (isLiveStream && json.has("live_stream") && !json.isNull("live_stream")) {
-            parseLiveStreamAssetInfo(json)
+            parseLiveStreamAssetInfo(json, title)
         } else {
-            parseVideoAssetInfo(json)
+            parseVideoAssetInfo(json, title)
         }
     }
 
-    private fun parseLiveStreamAssetInfo(json: JSONObject): AssetInfo {
+    private fun parseLiveStreamAssetInfo(json: JSONObject, title: String): AssetInfo {
         val liveStreamObj = json.getJSONObject("live_stream")
         val liveStreamStatus = liveStreamObj.optString("status", "")
         val shouldShowRecordedVideo = liveStreamObj.optBoolean("show_recorded_video", false)
@@ -51,7 +52,8 @@ class TestPressApiService : BaseApiService() {
                             thumbnailUrl = getThumbnail(videoObj),
                             videoObj = videoObj,
                             isLiveStream = false,
-                            durationSeconds = videoObj.optDouble("duration", 0.0)
+                            durationSeconds = videoObj.optDouble("duration", 0.0),
+                            title = title
                         )
                     } else {
                         throw LiveStreamEndedException("Live stream has ended")
@@ -68,13 +70,14 @@ class TestPressApiService : BaseApiService() {
                     thumbnailUrl = "",
                     videoObj = null,
                     isLiveStream = true,
-                    durationSeconds = liveStreamObj.optDouble("duration", 0.0)
+                    durationSeconds = liveStreamObj.optDouble("duration", 0.0),
+                    title = title
                 )
             }
         }
     }
 
-    private fun parseVideoAssetInfo(json: JSONObject): AssetInfo {
+    private fun parseVideoAssetInfo(json: JSONObject, title: String): AssetInfo {
         val videoObj = json.getJSONObject("video")
         val enableDrm = videoObj.optBoolean("drm_enabled", false)
         return AssetInfo(
@@ -83,7 +86,8 @@ class TestPressApiService : BaseApiService() {
             thumbnailUrl = getThumbnail(videoObj),
             videoObj = videoObj,
             isLiveStream = false,
-            durationSeconds = videoObj.optDouble("duration", 0.0)
+            durationSeconds = videoObj.optDouble("duration", 0.0),
+            title = title
         )
     }
 

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/api/TestPressApiService.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/api/TestPressApiService.kt
@@ -1,0 +1,103 @@
+package com.tpstreams.player.data.network.api
+
+import com.tpstreams.player.constants.LiveStreamEndedException
+import com.tpstreams.player.constants.LiveStreamNotStartedException
+import com.tpstreams.player.data.network.model.AssetInfo
+import org.json.JSONObject
+import java.util.Locale
+
+class TestPressApiService : BaseApiService() {
+    override fun assetInfoUrl(orgId: String, assetId: String, accessToken: String): String {
+        return "https://$orgId.testpress.in/api/v2.5/video_info/$assetId/?v=2&access_token=$accessToken"
+    }
+
+    override fun drmLicenseUrl(
+        orgId: String,
+        assetId: String,
+        accessToken: String,
+        download: Boolean,
+        licenseDurationSeconds: Long?
+    ): String {
+        return "https://$orgId.testpress.in/api/v2.5/drm_license_key/$assetId/?access_token=$accessToken"
+    }
+
+    override fun parseAsset(json: JSONObject): AssetInfo {
+        val contentType = json.optString("content_type", "video")
+        val isLiveStream = contentType == "livestream"
+
+        return if (isLiveStream && json.has("live_stream") && !json.isNull("live_stream")) {
+            parseLiveStreamAssetInfo(json)
+        } else {
+            parseVideoAssetInfo(json)
+        }
+    }
+
+    private fun parseLiveStreamAssetInfo(json: JSONObject): AssetInfo {
+        val liveStreamObj = json.getJSONObject("live_stream")
+        val liveStreamStatus = liveStreamObj.optString("status", "")
+        val shouldShowRecordedVideo = liveStreamObj.optBoolean("show_recorded_video", false)
+
+        return when (liveStreamStatus.uppercase(Locale.ROOT)) {
+            "NOT STARTED" -> throw LiveStreamNotStartedException("Live stream will begin soon")
+            "COMPLETED" -> {
+                if (shouldShowRecordedVideo && json.has("video") && !json.isNull("video")) {
+                    val videoObj = json.getJSONObject("video")
+                    val videoStatus = videoObj.optString("transcoding_status", "")
+                    if (videoStatus.equals("Completed", ignoreCase = true)) {
+                        val enableDrm = videoObj.optBoolean("drm_enabled", false)
+                        AssetInfo(
+                            mediaUrl = getVideoPlaybackUrl(videoObj, enableDrm),
+                            enableDrm = enableDrm,
+                            thumbnailUrl = getThumbnail(videoObj),
+                            videoObj = videoObj,
+                            isLiveStream = false,
+                            durationSeconds = videoObj.optDouble("duration", 0.0)
+                        )
+                    } else {
+                        throw LiveStreamEndedException("Live stream has ended")
+                    }
+                } else {
+                    throw LiveStreamEndedException("Live stream has ended")
+                }
+            }
+
+            else -> {
+                AssetInfo(
+                    mediaUrl = liveStreamObj.optString("stream_url", ""),
+                    enableDrm = false,
+                    thumbnailUrl = "",
+                    videoObj = null,
+                    isLiveStream = true,
+                    durationSeconds = liveStreamObj.optDouble("duration", 0.0)
+                )
+            }
+        }
+    }
+
+    private fun parseVideoAssetInfo(json: JSONObject): AssetInfo {
+        val videoObj = json.getJSONObject("video")
+        val enableDrm = videoObj.optBoolean("drm_enabled", false)
+        return AssetInfo(
+            mediaUrl = getVideoPlaybackUrl(videoObj, enableDrm),
+            enableDrm = enableDrm,
+            thumbnailUrl = getThumbnail(videoObj),
+            videoObj = videoObj,
+            isLiveStream = false,
+            durationSeconds = videoObj.optDouble("duration", 0.0)
+        )
+    }
+
+    private fun getVideoPlaybackUrl(videoObj: JSONObject, enableDrm: Boolean): String {
+        return if (enableDrm) {
+            videoObj.optString("dash_url")
+        } else {
+            videoObj.optString("url").ifEmpty { videoObj.optString("hls_url") }
+        }
+    }
+
+    private fun getThumbnail(videoObj: JSONObject): String {
+        return videoObj.optString("thumbnail")
+            .ifEmpty { videoObj.optString("thumbnail_medium") }
+            .ifEmpty { videoObj.optString("thumbnail_small") }
+    }
+}

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/model/AssetInfo.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/model/AssetInfo.kt
@@ -6,13 +6,16 @@ import org.json.JSONObject
  * Data class representing parsed asset information from backend API responses.
  * This class holds the essential playback information for both regular videos and live streams.
  *
+ * @property title The title of the asset
  * @property mediaUrl The URL to the media content (HLS or DASH)
  * @property enableDrm Whether DRM protection is enabled for this asset
  * @property thumbnailUrl URL to the thumbnail image (empty for active live streams)
  * @property videoObj The video JSON object containing additional metadata like tracks and thumbnails (null for active live streams)
  * @property isLiveStream Whether this asset is an active live stream (not recorded)
+ * @property durationSeconds Duration of the video in seconds
  */
 data class AssetInfo(
+    val title: String,
     val mediaUrl: String,
     val enableDrm: Boolean,
     val thumbnailUrl: String,

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/model/AssetInfo.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/model/AssetInfo.kt
@@ -1,9 +1,9 @@
-package com.tpstreams.player.data
+package com.tpstreams.player.data.network.model
 
 import org.json.JSONObject
 
 /**
- * Data class representing parsed asset information from the TPStreams API response.
+ * Data class representing parsed asset information from backend API responses.
  * This class holds the essential playback information for both regular videos and live streams.
  *
  * @property mediaUrl The URL to the media content (HLS or DASH)

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadClient.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadClient.kt
@@ -12,8 +12,8 @@ import androidx.media3.exoplayer.offline.DownloadManager
 import androidx.media3.exoplayer.offline.DownloadRequest
 import org.json.JSONObject
 import com.tpstreams.player.TPStreamsSDK
-import com.tpstreams.player.data.AssetInfo
 import com.tpstreams.player.data.AssetRepository
+import com.tpstreams.player.data.network.model.AssetInfo
 import com.tpstreams.player.constants.PlaybackError
 import com.tpstreams.player.DownloadOptionsBottomSheet
 import androidx.media3.common.MimeTypes
@@ -130,8 +130,8 @@ class DownloadClient private constructor(private val context: Context) {
         accessToken: String,
         callback: AssetRepository.AssetCallback
     ) {
-        val orgId = TPStreamsSDK.orgId ?: throw IllegalStateException("TPStreamsSDK.init(orgId) must be called first")
-        AssetRepository.fetchAssetInfo(orgId, assetId, accessToken, callback)
+        TPStreamsSDK.requireOrgId()
+        AssetRepository.fetchAssetInfo(assetId, accessToken, callback)
     }
 
     fun startDownload(
@@ -141,7 +141,7 @@ class DownloadClient private constructor(private val context: Context) {
         resolution: String? = null,
         metadata: Map<String, String>? = null
     ) {
-        val orgId = TPStreamsSDK.orgId ?: throw IllegalStateException("TPStreamsSDK.init(orgId) must be called first")
+        val orgId = TPStreamsSDK.requireOrgId()
 
         getAssetInfo(assetId, accessToken, object : AssetRepository.AssetCallback {
             override fun onSuccess(assetInfo: AssetInfo, title: String) {

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadClient.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadClient.kt
@@ -144,12 +144,12 @@ class DownloadClient private constructor(private val context: Context) {
         val orgId = TPStreamsSDK.requireOrgId()
 
         getAssetInfo(assetId, accessToken, object : AssetRepository.AssetCallback {
-            override fun onSuccess(assetInfo: AssetInfo, title: String) {
+            override fun onSuccess(assetInfo: AssetInfo) {
                 if (resolution != null) {
-                    performStartDownload(assetInfo, title, orgId, assetId, accessToken, resolution, metadata)
+                    performStartDownload(assetInfo, assetInfo.title, orgId, assetId, accessToken, resolution, metadata)
                 } else {
                     if (context is androidx.fragment.app.FragmentActivity) {
-                        showDownloadOptions(context, assetInfo, title, orgId, assetId, accessToken, metadata)
+                        showDownloadOptions(context, assetInfo, assetInfo.title, orgId, assetId, accessToken, metadata)
                     } else {
                         Log.e(TAG, "Resolution is required for non-activity contexts")
                     }

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/MediaItemUtils.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/MediaItemUtils.kt
@@ -7,7 +7,8 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.MimeTypes
 import androidx.media3.common.util.UnstableApi
-import com.tpstreams.player.data.AssetInfo
+import com.tpstreams.player.TPStreamsSDK
+import com.tpstreams.player.data.network.model.AssetInfo
 
 @UnstableApi
 object MediaItemUtils {
@@ -72,12 +73,11 @@ object MediaItemUtils {
                 setMediaMetadata(metadata)
                 
                 if (assetInfo.enableDrm) {
-                    val licenseUrl = "https://app.tpstreams.com/api/v1/$orgId/assets/$assetId/drm_license/?access_token=$accessToken"
-                    val drmHeaders = mapOf("Authorization" to "Bearer $accessToken")
-                    
+                    val apiService = TPStreamsSDK.apiService
+                    val licenseUrl = apiService.drmLicenseUrl(orgId, assetId, accessToken)
+
                     val drmConfig = MediaItem.DrmConfiguration.Builder(C.WIDEVINE_UUID)
                         .setLicenseUri(licenseUrl)
-                        .setLicenseRequestHeaders(drmHeaders)
                         .setMultiSession(true)
                         .build()
                     

--- a/tpstreams-android-player/src/test/java/com/tpstreams/player/TPStreamsSDKTest.kt
+++ b/tpstreams-android-player/src/test/java/com/tpstreams/player/TPStreamsSDKTest.kt
@@ -1,0 +1,26 @@
+package com.tpstreams.player
+
+import com.tpstreams.player.data.network.api.TPStreamsApiService
+import com.tpstreams.player.data.network.api.TestPressApiService
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TPStreamsSDKTest {
+
+    @Test
+    fun `test legacy init defaults to TPStreamsApiService`() {
+        TPStreamsSDK.init("test_org")
+        
+        assertEquals("test_org", TPStreamsSDK.orgId)
+        assertTrue(TPStreamsSDK.apiService is TPStreamsApiService)
+    }
+
+    @Test
+    fun `test init with Provider enum`() {
+        TPStreamsSDK.init("test_org", TPStreamsSDK.Provider.TestPress)
+        
+        assertEquals("test_org", TPStreamsSDK.orgId)
+        assertTrue(TPStreamsSDK.apiService is TestPressApiService)
+    }
+}

--- a/tpstreams-android-player/src/test/java/com/tpstreams/player/data/network/api/ApiServiceTest.kt
+++ b/tpstreams-android-player/src/test/java/com/tpstreams/player/data/network/api/ApiServiceTest.kt
@@ -1,0 +1,33 @@
+package com.tpstreams.player.data.network.api
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ApiServiceTest {
+    private val tpStreamsApi = TPStreamsApiService()
+    private val testPressApi = TestPressApiService()
+
+    @Test
+    fun `tpstreams api builds urls`() {
+        assertEquals(
+            "https://app.tpstreams.com/api/v1/org/assets/asset/?access_token=token",
+            tpStreamsApi.assetInfoUrl("org", "asset", "token")
+        )
+        assertEquals(
+            "https://app.tpstreams.com/api/v1/org/assets/asset/drm_license/?access_token=token&download=true&license_duration_seconds=1000",
+            tpStreamsApi.drmLicenseUrl("org", "asset", "token", download = true, licenseDurationSeconds = 1000)
+        )
+    }
+
+    @Test
+    fun `testpress api builds urls`() {
+        assertEquals(
+            "https://demo.testpress.in/api/v2.5/video_info/asset/?v=2&access_token=token",
+            testPressApi.assetInfoUrl("demo", "asset", "token")
+        )
+        assertEquals(
+            "https://demo.testpress.in/api/v2.5/drm_license_key/asset/?access_token=token",
+            testPressApi.drmLicenseUrl("demo", "asset", "token")
+        )
+    }
+}


### PR DESCRIPTION
- The SDK was previously hard-wired to TPStreams-specific endpoints and response 
formats, preventing its use for Testpress-backed content. This change 
introduces a provider-aware architecture to allow both products to share a 
single, unified player stack. 
- By abstracting API logic into provider-specific services and introducing a 
typesafe `Provider` enum, we eliminate the need for maintaining separate 
SDKs while ensuring full backward compatibility for existing TPStreams 
integrations.