### PR TITLE
feat: Add support for JWT authentication headers for Testpress provider

### DIFF
--- a/app/src/main/java/com/tpstreams/player/MainActivity.kt
+++ b/app/src/main/java/com/tpstreams/player/MainActivity.kt
@@ -13,6 +13,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.tpstreams.player.download.DownloadClient
 import com.tpstreams.player.download.DownloadItem
+import com.tpstreams.player.TestpressSDK
 
 @OptIn(UnstableApi::class)
 class MainActivity : AppCompatActivity() {
@@ -79,7 +80,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun initTestpress() {
-        TPStreamsSDK.init("lmsdemo", TPStreamsSDK.Provider.TestPress)
+        TestpressSDK.init("lmsdemo")
     }
 
     private fun setupDownloadsList() {
@@ -169,6 +170,7 @@ class MainActivity : AppCompatActivity() {
             val intent = Intent(this, PlayerActivity::class.java).apply {
                 putExtra(EXTRA_ASSET_ID, "ATJfRdHIUC9")
                 putExtra(EXTRA_ACCESS_TOKEN, "a4c04ca8-9c0e-4c9c-a889-bd3bf8ea586a")
+                putExtra(EXTRA_IS_TESTPRESS, true)
             }
             startActivity(intent)
         }
@@ -177,6 +179,7 @@ class MainActivity : AppCompatActivity() {
             val intent = Intent(this, PlayerActivity::class.java).apply {
                 putExtra(EXTRA_ASSET_ID, "z1TLpfuZzXh")
                 putExtra(EXTRA_ACCESS_TOKEN, "5c49285b-0557-4cef-b214-66034d0b77c3")
+                putExtra(EXTRA_IS_TESTPRESS, true)
             }
             startActivity(intent)
         }
@@ -190,5 +193,6 @@ class MainActivity : AppCompatActivity() {
     companion object {
         const val EXTRA_ASSET_ID = "extra_asset_id"
         const val EXTRA_ACCESS_TOKEN = "extra_access_token"
+        const val EXTRA_IS_TESTPRESS = "extra_is_testpress"
     }
 }

--- a/app/src/main/java/com/tpstreams/player/PlayerActivity.kt
+++ b/app/src/main/java/com/tpstreams/player/PlayerActivity.kt
@@ -21,8 +21,9 @@ class PlayerActivity : AppCompatActivity() {
 
         val assetId = intent.getStringExtra(MainActivity.EXTRA_ASSET_ID) ?: return
         val accessToken = intent.getStringExtra(MainActivity.EXTRA_ACCESS_TOKEN) ?: return
+        val isTestpress = intent.getBooleanExtra(MainActivity.EXTRA_IS_TESTPRESS, false)
 
-        viewModel.initPlayer(assetId, accessToken)
+        viewModel.initPlayer(assetId, accessToken, isTestpress)
         binding.playerView.player = viewModel.player
     }
 }

--- a/app/src/main/java/com/tpstreams/player/PlayerUIViewModel.kt
+++ b/app/src/main/java/com/tpstreams/player/PlayerUIViewModel.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.annotation.OptIn
 import androidx.media3.common.util.UnstableApi
 import androidx.lifecycle.AndroidViewModel
+import com.tpstreams.player.TestpressPlayer
 
 @OptIn(UnstableApi::class)
 class PlayerUIViewModel(application: Application) : AndroidViewModel(application) {
@@ -12,15 +13,25 @@ class PlayerUIViewModel(application: Application) : AndroidViewModel(application
     val player: TPStreamsPlayer?
         get() = _player
 
-    fun initPlayer(assetId: String, accessToken: String) {
+    fun initPlayer(assetId: String, accessToken: String, isTestpress: Boolean = false) {
         if (_player == null) {
-            _player = TPStreamsPlayer.create(
-                context = getApplication<Application>().applicationContext,
-                assetId = assetId,
-                accessToken = accessToken,
-                shouldAutoPlay = true,
-                enableDownload = true
-            )
+            _player = if (isTestpress) {
+                TestpressPlayer.create(
+                    context = getApplication<Application>().applicationContext,
+                    assetId = assetId,
+                    accessToken = accessToken,
+                    shouldAutoPlay = true,
+                    enableDownload = true
+                )
+            } else {
+                TPStreamsPlayer.create(
+                    context = getApplication<Application>().applicationContext,
+                    assetId = assetId,
+                    accessToken = accessToken,
+                    shouldAutoPlay = true,
+                    enableDownload = true
+                )
+            }
         }
     }
 

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/DownloadActions.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/DownloadActions.kt
@@ -115,14 +115,17 @@ class DownloadActions(private val view: TPStreamsPlayerView) {
             .clearQuery()
             .appendQueryParameter("access_token", token)
             .build()
-    
-        val newDrm = MediaItem.DrmConfiguration.Builder(C.WIDEVINE_UUID)
+
+        val authHeaders = TPStreamsSDK.getAuthHeaders()
+        val drmBuilder = MediaItem.DrmConfiguration.Builder(C.WIDEVINE_UUID)
             .setLicenseUri(newUri)
-            .setLicenseRequestHeaders(mapOf("Authorization" to "Bearer $token"))
             .setMultiSession(true)
-            .build()
+
+        if (authHeaders.isNotEmpty()) {
+            drmBuilder.setLicenseRequestHeaders(authHeaders)
+        }
     
-        return buildUpon().setDrmConfiguration(newDrm).build()
+        return buildUpon().setDrmConfiguration(drmBuilder.build()).build()
     }
 
     fun deleteCurrentDownload() {

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -650,10 +650,15 @@ private constructor(
             CoroutineScope(Dispatchers.IO).launch {
                 try {
                     val assetApiUrl = TPStreamsSDK.apiService.tokenValidationUrl(orgId, assetId, accessToken)
-                    val request = Request.Builder()
+                    val requestBuilder = Request.Builder()
                         .url(assetApiUrl)
                         .head()
-                        .build()
+
+                    TPStreamsSDK.getAuthHeaders().forEach { (name, value) ->
+                        requestBuilder.addHeader(name, value)
+                    }
+
+                    val request = requestBuilder.build()
                     
                     val response = client.newCall(request).execute()
                     val isValid = response.isSuccessful

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -636,7 +636,7 @@ private constructor(
         Log.d("TPStreamsPlayer", "Checking if token is valid for asset: $assetId")
         
         CoroutineScope(Dispatchers.Main).launch {
-            if (accessToken.isEmpty()) {
+            if (accessToken.isEmpty() && TPStreamsSDK.getAuthHeaders().isEmpty()) {
                 Log.d("TPStreamsPlayer", "No current token available")
                 callback(false)
                 return@launch

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsSDK.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsSDK.kt
@@ -13,6 +13,8 @@ object TPStreamsSDK {
 
     internal lateinit var apiService: BaseApiService
     private var _orgCode: String? = null
+    internal var authToken: String? = null
+        private set
 
     internal var orgId: String?
         get() = _orgCode
@@ -22,13 +24,22 @@ object TPStreamsSDK {
 
     @JvmStatic
     @JvmOverloads
-    fun init(orgId: String, provider: Provider = Provider.TPStreams) {
+    fun init(orgId: String, provider: Provider = Provider.TPStreams, authToken: String? = null) {
         require(orgId.isNotBlank()) { "orgId cannot be empty." }
+        if (provider == Provider.TPStreams && authToken != null) {
+            throw IllegalArgumentException("authToken must be null for TPStreams provider")
+        }
+
         apiService = when (provider) {
             Provider.TPStreams -> TPStreamsApiService()
             Provider.TestPress -> TestPressApiService()
         }
         _orgCode = orgId
+        this.authToken = authToken
+    }
+
+    internal fun getAuthHeaders(): Map<String, String> {
+        return authToken?.let { mapOf("Authorization" to "JWT $it") } ?: emptyMap()
     }
 
     internal fun requireOrgId(): String {

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TestpressPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TestpressPlayer.kt
@@ -1,0 +1,37 @@
+package com.tpstreams.player
+
+import android.content.Context
+import androidx.media3.common.util.UnstableApi
+import com.tpstreams.player.download.DownloadConstants
+
+object TestpressPlayer {
+
+    @OptIn(UnstableApi::class)
+    @JvmStatic
+    @JvmOverloads
+    fun create(
+        context: Context,
+        assetId: String,
+        accessToken: String = "",
+        shouldAutoPlay: Boolean = true,
+        startAt: Long = 0,
+        enableDownload: Boolean = false,
+        showDefaultCaptions: Boolean = false,
+        startInFullscreen: Boolean = false,
+        downloadMetadata: Map<String, String>? = null,
+        offlineLicenseExpireTime: Long = DownloadConstants.FIFTEEN_DAYS_IN_SECONDS
+    ): TPStreamsPlayer {
+        return TPStreamsPlayer.create(
+            context,
+            assetId,
+            accessToken,
+            shouldAutoPlay,
+            startAt,
+            enableDownload,
+            showDefaultCaptions,
+            startInFullscreen,
+            downloadMetadata,
+            offlineLicenseExpireTime
+        )
+    }
+}

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TestpressSDK.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TestpressSDK.kt
@@ -1,0 +1,14 @@
+package com.tpstreams.player
+
+object TestpressSDK {
+    /**
+     * Initialize the SDK for Testpress.
+     * @param subdomain The subdomain (orgCode) for Testpress.
+     * @param authToken Optional JWT token for authentication.
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun init(subdomain: String, authToken: String? = null) {
+        TPStreamsSDK.init(subdomain, TPStreamsSDK.Provider.TestPress, authToken)
+    }
+}

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/data/AssetRepository.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/data/AssetRepository.kt
@@ -35,7 +35,11 @@ object AssetRepository {
         CoroutineScope(Dispatchers.IO).launch {
             try {
                 val assetApiUrl = apiService.assetInfoUrl(orgId, assetId, accessToken)
-                val request = Request.Builder().url(assetApiUrl).build()
+                val requestBuilder = Request.Builder().url(assetApiUrl)
+                TPStreamsSDK.getAuthHeaders().forEach { (name, value) ->
+                    requestBuilder.addHeader(name, value)
+                }
+                val request = requestBuilder.build()
                 val response = client.newCall(request).execute()
 
                 if (!response.isSuccessful) {

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/MediaItemUtils.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/MediaItemUtils.kt
@@ -76,12 +76,15 @@ object MediaItemUtils {
                     val apiService = TPStreamsSDK.apiService
                     val licenseUrl = apiService.drmLicenseUrl(orgId, assetId, accessToken)
 
-                    val drmConfig = MediaItem.DrmConfiguration.Builder(C.WIDEVINE_UUID)
+                    val drmConfigBuilder = MediaItem.DrmConfiguration.Builder(C.WIDEVINE_UUID)
                         .setLicenseUri(licenseUrl)
                         .setMultiSession(true)
-                        .build()
-                    
-                    setDrmConfiguration(drmConfig)
+
+                    val authHeaders = TPStreamsSDK.getAuthHeaders()
+                    if (authHeaders.isNotEmpty()) {
+                        drmConfigBuilder.setLicenseRequestHeaders(authHeaders)
+                    }
+                    setDrmConfiguration(drmConfigBuilder.build())
                 }
                 
                 if (subtitleConfigurations.isNotEmpty()) {

--- a/tpstreams-android-player/src/test/java/com/tpstreams/player/TPStreamsSDKTest.kt
+++ b/tpstreams-android-player/src/test/java/com/tpstreams/player/TPStreamsSDKTest.kt
@@ -23,4 +23,24 @@ class TPStreamsSDKTest {
         assertEquals("test_org", TPStreamsSDK.orgId)
         assertTrue(TPStreamsSDK.apiService is TestPressApiService)
     }
+
+    @Test
+    fun `test init with authToken for TestPress`() {
+        TPStreamsSDK.init("test_org", TPStreamsSDK.Provider.TestPress, "test_auth_token")
+
+        assertEquals("test_auth_token", TPStreamsSDK.authToken)
+        val headers = TPStreamsSDK.getAuthHeaders()
+        assertEquals("JWT test_auth_token", headers["Authorization"])
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `test init with authToken for TPStreams throws exception`() {
+        TPStreamsSDK.init("test_org", TPStreamsSDK.Provider.TPStreams, "test_auth_token")
+    }
+
+    @Test
+    fun `test getAuthHeaders returns empty when no authToken`() {
+        TPStreamsSDK.init("test_org", TPStreamsSDK.Provider.TestPress, null)
+        assertTrue(TPStreamsSDK.getAuthHeaders().isEmpty())
+    }
 }


### PR DESCRIPTION
- To align the Android SDK with the iOS implementation and support the Testpress provider's dual-token authentication system. This transition was necessary because platforms like Testpress require a global user/session JWT in the request headers for platform-level authorization, while still utilizing the asset-specific access token as a query parameter in the URL. 
- This ensures that both video metadata and DRM license requests are correctly authenticated for logged-in users, enabling a consistent security posture across all mobile platforms.