### PR TITLE
fix: Enable decoder fallback for improved playback and download stability

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -704,6 +704,9 @@ private constructor(
                     .build()
             }
 
+            val renderersFactory = DefaultRenderersFactory(context)
+                .setEnableDecoderFallback(true)
+
             DownloadController.initialize(context)
 
             val cacheDataSourceFactory = CacheDataSource.Factory()
@@ -714,7 +717,7 @@ private constructor(
             val mediaSourceFactory = DefaultMediaSourceFactory(context)
                 .setDataSourceFactory(cacheDataSourceFactory)
 
-            return ExoPlayer.Builder(context)
+            return ExoPlayer.Builder(context, renderersFactory)
                 .setMediaSourceFactory(mediaSourceFactory)
                 .setTrackSelector(trackSelector)
                 .setAudioAttributes(

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -12,6 +12,7 @@ import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import kotlinx.coroutines.CoroutineScope
@@ -704,7 +705,7 @@ private constructor(
                     .build()
             }
 
-            val renderersFactory = DefaultRenderersFactory(context)
+            val renderersFactory = DefaultRenderersFactory(context.applicationContext)
                 .setEnableDecoderFallback(true)
 
             DownloadController.initialize(context)

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadController.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadController.kt
@@ -214,7 +214,7 @@ object DownloadController {
         val helper = DownloadHelper.forMediaItem(
             mediaItem,
             TrackSelectionParameters.Builder().build(),
-            DefaultRenderersFactory(context),
+            createRenderersFactory(context),
             getDataSourceFactory(context)
         )
 
@@ -270,6 +270,10 @@ object DownloadController {
         return DefaultDataSource.Factory(context, httpDataSourceFactory)
     }
     
+    private fun createRenderersFactory(context: Context): DefaultRenderersFactory {
+        return DefaultRenderersFactory(context).setEnableDecoderFallback(true)
+    }
+    
     fun startDownload(context: Context, mediaItem: MediaItem, resolution: String, metadata: Map<String, String>, totalSize: Long = 0, offlineLicenseExpireTime: Long = DownloadConstants.FIFTEEN_DAYS_IN_SECONDS) {
         Log.d(TAG, "Preparing download for: ${mediaItem.mediaId}")
         val title = mediaItem.mediaMetadata.title?.toString() ?: "Undefined"
@@ -280,7 +284,7 @@ object DownloadController {
         val helper = DownloadHelper.forMediaItem(
             mediaItem,
             trackSelectionParameters,
-            DefaultRenderersFactory(context),
+            createRenderersFactory(context),
             getDataSourceFactory(context)
         )
         
@@ -448,7 +452,7 @@ object DownloadController {
         val helper = DownloadHelper.forMediaItem(
             newMediaItem,
             TrackSelectionParameters.Builder().build(),
-            DefaultRenderersFactory(context),
+            createRenderersFactory(context),
             getDataSourceFactory(context)
         )
         

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadController.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadController.kt
@@ -271,7 +271,7 @@ object DownloadController {
     }
     
     private fun createRenderersFactory(context: Context): DefaultRenderersFactory {
-        return DefaultRenderersFactory(context).setEnableDecoderFallback(true)
+        return DefaultRenderersFactory(context.applicationContext).setEnableDecoderFallback(true)
     }
     
     fun startDownload(context: Context, mediaItem: MediaItem, resolution: String, metadata: Map<String, String>, totalSize: Long = 0, offlineLicenseExpireTime: Long = DownloadConstants.FIFTEEN_DAYS_IN_SECONDS) {

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadController.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadController.kt
@@ -270,7 +270,7 @@ object DownloadController {
         return DefaultDataSource.Factory(context, httpDataSourceFactory)
     }
     
-    private fun createRenderersFactory(context: Context): DefaultRenderersFactory {
+    internal fun createRenderersFactory(context: Context): DefaultRenderersFactory {
         return DefaultRenderersFactory(context.applicationContext).setEnableDecoderFallback(true)
     }
     


### PR DESCRIPTION
- This change improves playback reliability on devices where hardware decoders fail to initialize (e.g., MediaTek secure codecs causing ERROR_CODE_DECODER_INIT_FAILED).
- Previously, ExoPlayer would fail immediately when the selected decoder couldn’t be initialized, even if alternative decoders were available. By enabling decoder fallback, the player can automatically retry with other decoders (including non-secure or software), reducing playback failures.
- This ensures more resilient playback across a wider range of devices and aligns both streaming and download flows with this behavior.