### PR TITLE
feat: Add clock drift diagnostics to error reports

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -51,6 +51,7 @@ import androidx.media3.exoplayer.analytics.AnalyticsListener
 import androidx.media3.exoplayer.DecoderReuseEvaluation
 import com.tpstreams.player.util.PlaybackHistoryManager
 import com.tpstreams.player.util.CodecManager
+import com.tpstreams.player.util.ServerDateHeaderInterceptor
 
 
 
@@ -698,7 +699,9 @@ private constructor(
     companion object {
         private var activePlayerCount = 0
         internal const val DEBUG_TAG = "PLAYBACK_ERROR_DEBUG"
-        private val client = OkHttpClient()
+        private val client = OkHttpClient.Builder()
+            .addInterceptor(ServerDateHeaderInterceptor())
+            .build()
 
 
 

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/data/AssetRepository.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/data/AssetRepository.kt
@@ -5,6 +5,7 @@ import com.tpstreams.player.constants.PlaybackError
 import com.tpstreams.player.constants.getErrorMessage
 import com.tpstreams.player.constants.toPlaybackError
 import com.tpstreams.player.data.network.model.AssetInfo
+import com.tpstreams.player.util.ServerDateHeaderInterceptor
 import com.tpstreams.player.util.SentryLogger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -17,7 +18,9 @@ import org.json.JSONObject
  * Repository for fetching and parsing asset metadata from configured backend providers.
  */
 object AssetRepository {
-    private val client = OkHttpClient()
+    private val client = OkHttpClient.Builder()
+        .addInterceptor(ServerDateHeaderInterceptor())
+        .build()
 
     interface AssetCallback {
         fun onSuccess(assetInfo: AssetInfo)

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/ClockDriftDiagnostics.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/ClockDriftDiagnostics.kt
@@ -1,0 +1,116 @@
+package com.tpstreams.player.util
+
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Lightweight clock/time context that can be attached to Sentry events.
+ *
+ * - server time comes from HTTP "Date" response headers (if observed).
+ */
+internal object ClockDriftDiagnostics {
+
+    // serverOffsetMs = serverEpochMs - deviceEpochMs (at time we observed the server "Date" header)
+    private val serverOffsetMs = AtomicLong(UNKNOWN_LONG)
+    private val lastServerDateHeaderEpochMs = AtomicLong(UNKNOWN_LONG)
+    private val lastServerDateObservedAtEpochMs = AtomicLong(UNKNOWN_LONG)
+
+    private val rfc1123Parser = ThreadLocal.withInitial {
+        SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US).apply {
+            timeZone = TimeZone.getTimeZone("GMT")
+        }
+    }
+
+    private val humanLocalFormatter = ThreadLocal.withInitial {
+        // Example: 2026-04-24 16:41:20.465 +05:30
+        SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS XXX", Locale.US).apply {
+            timeZone = TimeZone.getDefault()
+        }
+    }
+
+    fun recordServerDateHeader(dateHeader: String?, observedAtEpochMs: Long = System.currentTimeMillis()) {
+        if (dateHeader.isNullOrBlank()) return
+
+        val parsedEpochMs = try {
+            rfc1123Parser.get()?.parse(dateHeader)?.time
+        } catch (_: Throwable) {
+            null
+        } ?: return
+
+        lastServerDateHeaderEpochMs.set(parsedEpochMs)
+        lastServerDateObservedAtEpochMs.set(observedAtEpochMs)
+        serverOffsetMs.set(parsedEpochMs - observedAtEpochMs)
+    }
+
+    fun buildSentryClockTags(nowEpochMs: Long = System.currentTimeMillis()): Map<String, String> {
+        val tags = linkedMapOf<String, String>()
+
+        tags["device.current_time"] = formatHumanLocal(nowEpochMs)
+
+        val offset = getServerOffsetMs()
+        if (offset != null) {
+            val serverNow = nowEpochMs + offset
+            val driftMs = nowEpochMs - serverNow
+            tags["device.server_time"] = formatHumanLocal(serverNow)
+            tags["device.time_drift_ms"] = driftMs.toString()
+            tags["device.time_drift"] = formatDurationMs(driftMs)
+            tags["device.server_time_source"] = "http_date_header"
+        }
+
+        return tags
+    }
+
+    fun buildSentryClockContext(nowEpochMs: Long = System.currentTimeMillis()): Map<String, Any> {
+        val context = linkedMapOf<String, Any>()
+
+        context["device.current_time"] = formatHumanLocal(nowEpochMs)
+
+        val offset = getServerOffsetMs()
+        if (offset != null) {
+            val serverNow = nowEpochMs + offset
+            val driftMs = nowEpochMs - serverNow
+            context["server.time"] = formatHumanLocal(serverNow)
+            context["device.time_drift_ms"] = driftMs
+            context["device.time_drift"] = formatDurationMs(driftMs)
+            context["server.time_source"] = "http_date_header"
+        }
+
+        return context
+    }
+
+    private fun formatHumanLocal(epochMs: Long): String {
+        return humanLocalFormatter.get()?.format(Date(epochMs)) ?: epochMs.toString()
+    }
+
+    private fun formatDurationMs(durationMs: Long): String {
+        val isNegative = durationMs < 0
+        var remainingMs = kotlin.math.abs(durationMs)
+
+        val totalSeconds = remainingMs / 1000
+        remainingMs %= 1000
+
+        val seconds = (totalSeconds % 60).toInt()
+        val totalMinutes = totalSeconds / 60
+        val minutes = (totalMinutes % 60).toInt()
+        val hours = (totalMinutes / 60).toInt()
+
+        val sign = if (isNegative) "-" else "+"
+        return if (hours > 0) {
+            String.format(Locale.US, "%s%dh %dm %ds", sign, hours, minutes, seconds)
+        } else if (minutes > 0) {
+            String.format(Locale.US, "%s%dm %ds", sign, minutes, seconds)
+        } else {
+            String.format(Locale.US, "%s%ds", sign, seconds)
+        }
+    }
+
+    private fun getServerOffsetMs(): Long? {
+        val offset = serverOffsetMs.get()
+        return if (offset == UNKNOWN_LONG) null else offset
+    }
+
+    private const val UNKNOWN_LONG = Long.MIN_VALUE
+}

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/SentryLogger.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/SentryLogger.kt
@@ -1,9 +1,6 @@
 package com.tpstreams.player.util
 
-import android.util.Log
 import androidx.media3.common.PlaybackException
-import com.tpstreams.player.TPStreamsPlayer
-import com.tpstreams.player.util.PlaybackHistoryManager
 import io.sentry.Sentry
 
 internal object SentryLogger {
@@ -21,6 +18,11 @@ internal object SentryLogger {
         playerId: String
     ) {
         Sentry.captureException(error) { scope ->
+            val nowEpochMs = System.currentTimeMillis()
+            ClockDriftDiagnostics.buildSentryClockTags(nowEpochMs).forEach { (key, value) ->
+                scope.setTag(key, value)
+            }
+            scope.setContexts("Clock Drift", ClockDriftDiagnostics.buildSentryClockContext(nowEpochMs))
             scope.setTag("playerId", playerId)
             assetId?.let { scope.setTag("assetId", it) }
             scope.setContexts(
@@ -46,6 +48,11 @@ internal object SentryLogger {
         playerId: String
     ) {
         Sentry.captureException(exception) { scope ->
+            val nowEpochMs = System.currentTimeMillis()
+            ClockDriftDiagnostics.buildSentryClockTags(nowEpochMs).forEach { (key, value) ->
+                scope.setTag(key, value)
+            }
+            scope.setContexts("Clock Drift", ClockDriftDiagnostics.buildSentryClockContext(nowEpochMs))
             scope.setTag("playerId", playerId)
             assetId?.let { scope.setTag("assetId", it) }
             responseCode?.let { scope.setTag("responseCode", it.toString()) }

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/ServerDateHeaderInterceptor.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/ServerDateHeaderInterceptor.kt
@@ -1,0 +1,16 @@
+package com.tpstreams.player.util
+
+import okhttp3.Interceptor
+import okhttp3.Response
+
+/**
+ * Records the server-provided "Date" header so we can estimate device↔server time drift later.
+ */
+internal class ServerDateHeaderInterceptor : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val response = chain.proceed(chain.request())
+        ClockDriftDiagnostics.recordServerDateHeader(response.header("Date"))
+        return response
+    }
+}
+


### PR DESCRIPTION
- Implement system to calculate offset between device and server time
- Add interceptor to capture date header from network responses
- Enrich error reports with device and server time diagnostics
- Include human-readable time drift in event tags and context
- Enable tracking of server time in network clients