### PR TITLE
fix: Resolve AES encryption key fetch failure causing playback errors

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/api/TPStreamsApiService.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/api/TPStreamsApiService.kt
@@ -8,7 +8,8 @@ import java.util.Locale
 
 class TPStreamsApiService : BaseApiService() {
     override fun assetInfoUrl(orgId: String, assetId: String, accessToken: String): String {
-        return "https://app.tpstreams.com/api/v1/$orgId/assets/$assetId/?access_token=$accessToken"
+        val baseUrl = "https://app.tpstreams.com/api/v1/$orgId/assets/$assetId/"
+        return if (accessToken.isNotBlank()) "$baseUrl?access_token=$accessToken" else baseUrl
     }
 
     override fun drmLicenseUrl(
@@ -18,10 +19,12 @@ class TPStreamsApiService : BaseApiService() {
         download: Boolean,
         licenseDurationSeconds: Long?
     ): String {
-        val baseUrl = "https://app.tpstreams.com/api/v1/$orgId/assets/$assetId/drm_license/?access_token=$accessToken"
-        if (!download) return baseUrl
+        val baseUrl = "https://app.tpstreams.com/api/v1/$orgId/assets/$assetId/drm_license/"
+        val withToken = if (accessToken.isNotBlank()) "$baseUrl?access_token=$accessToken" else baseUrl
+        if (!download) return withToken
         val duration = licenseDurationSeconds ?: 0L
-        return "$baseUrl&download=true&license_duration_seconds=$duration"
+        val separator = if (withToken.contains("?")) "&" else "?"
+        return "$withToken${separator}download=true&license_duration_seconds=$duration"
     }
 
     override fun parseAsset(json: JSONObject): AssetInfo {
@@ -48,6 +51,7 @@ class TPStreamsApiService : BaseApiService() {
 
                     if (videoStatus.equals("Completed", ignoreCase = true)) {
                         val enableDrm = videoObj.optBoolean("enable_drm", false)
+                        val isAes = videoObj.optString("content_protection_type").equals("aes", ignoreCase = true)
                         AssetInfo(
                             mediaUrl = getVideoPlaybackUrl(videoObj, enableDrm),
                             enableDrm = enableDrm,
@@ -55,7 +59,8 @@ class TPStreamsApiService : BaseApiService() {
                             videoObj = videoObj,
                             isLiveStream = false,
                             durationSeconds = videoObj.optDouble("duration", 0.0),
-                            title = title
+                            title = title,
+                            isAes = isAes
                         )
                     } else {
                         throw LiveStreamEndedException("Live stream has ended")
@@ -88,6 +93,7 @@ class TPStreamsApiService : BaseApiService() {
     private fun parseVideoAssetInfo(json: JSONObject, title: String): AssetInfo {
         val videoObj = json.getJSONObject("video")
         val enableDrm = videoObj.optBoolean("enable_drm", false)
+        val isAes = videoObj.optString("content_protection_type").equals("aes", ignoreCase = true)
         return AssetInfo(
             mediaUrl = getVideoPlaybackUrl(videoObj, enableDrm),
             enableDrm = enableDrm,
@@ -95,7 +101,8 @@ class TPStreamsApiService : BaseApiService() {
             videoObj = videoObj,
             isLiveStream = false,
             durationSeconds = videoObj.optDouble("duration", 0.0),
-            title = title
+            title = title,
+            isAes = isAes
         )
     }
 

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/api/TestPressApiService.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/api/TestPressApiService.kt
@@ -8,7 +8,8 @@ import java.util.Locale
 
 class TestPressApiService : BaseApiService() {
     override fun assetInfoUrl(orgId: String, assetId: String, accessToken: String): String {
-        return "https://$orgId.testpress.in/api/v2.5/video_info/$assetId/?v=2&access_token=$accessToken"
+        val baseUrl = "https://$orgId.testpress.in/api/v2.5/video_info/$assetId/?v=2"
+        return if (accessToken.isNotBlank()) "$baseUrl&access_token=$accessToken" else baseUrl
     }
 
     override fun drmLicenseUrl(
@@ -18,7 +19,8 @@ class TestPressApiService : BaseApiService() {
         download: Boolean,
         licenseDurationSeconds: Long?
     ): String {
-        return "https://$orgId.testpress.in/api/v2.5/drm_license_key/$assetId/?access_token=$accessToken"
+        val baseUrl = "https://$orgId.testpress.in/api/v2.5/drm_license_key/$assetId/"
+        return if (accessToken.isNotBlank()) "$baseUrl?access_token=$accessToken" else baseUrl
     }
 
     override fun parseAsset(json: JSONObject): AssetInfo {
@@ -45,16 +47,7 @@ class TestPressApiService : BaseApiService() {
                     val videoObj = json.getJSONObject("video")
                     val videoStatus = videoObj.optString("transcoding_status", "")
                     if (videoStatus.equals("Completed", ignoreCase = true)) {
-                        val enableDrm = videoObj.optBoolean("drm_enabled", false)
-                        AssetInfo(
-                            mediaUrl = getVideoPlaybackUrl(videoObj, enableDrm),
-                            enableDrm = enableDrm,
-                            thumbnailUrl = getThumbnail(videoObj),
-                            videoObj = videoObj,
-                            isLiveStream = false,
-                            durationSeconds = videoObj.optDouble("duration", 0.0),
-                            title = title
-                        )
+                        createVideoAssetInfo(videoObj, title)
                     } else {
                         throw LiveStreamEndedException("Live stream has ended")
                     }
@@ -79,6 +72,10 @@ class TestPressApiService : BaseApiService() {
 
     private fun parseVideoAssetInfo(json: JSONObject, title: String): AssetInfo {
         val videoObj = json.getJSONObject("video")
+        return createVideoAssetInfo(videoObj, title)
+    }
+
+    private fun createVideoAssetInfo(videoObj: JSONObject, title: String): AssetInfo {
         val enableDrm = videoObj.optBoolean("drm_enabled", false)
         return AssetInfo(
             mediaUrl = getVideoPlaybackUrl(videoObj, enableDrm),
@@ -87,8 +84,13 @@ class TestPressApiService : BaseApiService() {
             videoObj = videoObj,
             isLiveStream = false,
             durationSeconds = videoObj.optDouble("duration", 0.0),
-            title = title
+            title = title,
+            isAes = isAesProtected(videoObj)
         )
+    }
+
+    private fun isAesProtected(videoObj: JSONObject): Boolean {
+        return videoObj.optString("content_protection_type").equals("aes", ignoreCase = true)
     }
 
     private fun getVideoPlaybackUrl(videoObj: JSONObject, enableDrm: Boolean): String {

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/model/AssetInfo.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/model/AssetInfo.kt
@@ -13,6 +13,7 @@ import org.json.JSONObject
  * @property videoObj The video JSON object containing additional metadata like tracks and thumbnails (null for active live streams)
  * @property isLiveStream Whether this asset is an active live stream (not recorded)
  * @property durationSeconds Duration of the video in seconds
+ * @property isAes Whether the stream uses AES content protection
  */
 data class AssetInfo(
     val title: String,
@@ -21,5 +22,6 @@ data class AssetInfo(
     val thumbnailUrl: String,
     val videoObj: JSONObject?,
     val isLiveStream: Boolean = false,
-    val durationSeconds: Double = 0.0
+    val durationSeconds: Double = 0.0,
+    val isAes: Boolean = false
 )

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadController.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadController.kt
@@ -111,15 +111,13 @@ object DownloadController {
             object : ResolvingDataSource.Resolver {
                 override fun resolveDataSpec(dataSpec: DataSpec): DataSpec {
                     var currentUri = dataSpec.uri
-                    val originalUriString = currentUri.toString()
-
                     var currentHeaders = dataSpec.httpRequestHeaders.toMutableMap()
 
-                    currentUri = captureAndStripTransientToken(currentUri, tokenCache)
+                    currentUri = extractTpToken(currentUri, tokenCache)
 
-                    if (isAesKeyRequest(currentUri)) {
-                        currentHeaders = addAesAuthHeaders(currentHeaders)
-                        currentUri = addAccessTokenIfMissing(currentUri, tokenCache)
+                    if (isEncryptionKeyRequest(currentUri)) {
+                        currentHeaders = withAuthHeaders(currentHeaders)
+                        currentUri = withAccessToken(currentUri, tokenCache)
                     }
 
                     return dataSpec.buildUpon()
@@ -128,7 +126,7 @@ object DownloadController {
                         .build()
                 }
 
-                private fun captureAndStripTransientToken(
+                private fun extractTpToken(
                     uri: Uri,
                     tokenCache: java.util.concurrent.ConcurrentHashMap<String, String>
                 ): Uri {
@@ -149,7 +147,7 @@ object DownloadController {
                     return newUriBuilder.build()
                 }
 
-                private fun addAesAuthHeaders(headers: MutableMap<String, String>): MutableMap<String, String> {
+                private fun withAuthHeaders(headers: MutableMap<String, String>): MutableMap<String, String> {
                     val authHeaders = TPStreamsSDK.getAuthHeaders()
                     if (authHeaders.isNotEmpty()) {
                         headers.putAll(authHeaders)
@@ -157,7 +155,7 @@ object DownloadController {
                     return headers
                 }
 
-                private fun addAccessTokenIfMissing(
+                private fun withAccessToken(
                     uri: Uri,
                     tokenCache: java.util.concurrent.ConcurrentHashMap<String, String>
                 ): Uri {
@@ -170,7 +168,7 @@ object DownloadController {
                         .build()
                 }
 
-                private fun isAesKeyRequest(uri: Uri): Boolean {
+                private fun isEncryptionKeyRequest(uri: Uri): Boolean {
                     val normalized = uri.toString()
                     return normalized.contains("encryption_key", ignoreCase = true) ||
                         normalized.contains("aes_key", ignoreCase = true)

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadController.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/download/DownloadController.kt
@@ -11,8 +11,10 @@ import androidx.media3.common.util.Util
 import androidx.media3.database.DatabaseProvider
 import androidx.media3.database.StandaloneDatabaseProvider
 import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DataSpec
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.DefaultHttpDataSource
+import androidx.media3.datasource.ResolvingDataSource
 import androidx.media3.datasource.cache.Cache
 import androidx.media3.datasource.cache.NoOpCacheEvictor
 import androidx.media3.datasource.cache.SimpleCache
@@ -37,6 +39,7 @@ import org.json.JSONObject
 import android.net.Uri
 import androidx.media3.exoplayer.offline.DefaultDownloadIndex
 import com.tpstreams.player.TPStreamsPlayer
+import com.tpstreams.player.TPStreamsSDK
 
 
 @UnstableApi
@@ -95,11 +98,91 @@ object DownloadController {
             databaseProvider
         )
         
-        httpDataSourceFactory = DefaultHttpDataSource.Factory()
+        val baseDataSourceFactory = DefaultHttpDataSource.Factory()
             .setConnectTimeoutMs(30000)
             .setReadTimeoutMs(30000)
             .setAllowCrossProtocolRedirects(true)
             .setUserAgent(Util.getUserAgent(appContext, "TPStreams Player"))
+
+        val tokenCache = java.util.concurrent.ConcurrentHashMap<String, String>()
+
+        httpDataSourceFactory = ResolvingDataSource.Factory(
+            baseDataSourceFactory,
+            object : ResolvingDataSource.Resolver {
+                override fun resolveDataSpec(dataSpec: DataSpec): DataSpec {
+                    var currentUri = dataSpec.uri
+                    val originalUriString = currentUri.toString()
+
+                    var currentHeaders = dataSpec.httpRequestHeaders.toMutableMap()
+
+                    currentUri = captureAndStripTransientToken(currentUri, tokenCache)
+
+                    if (isAesKeyRequest(currentUri)) {
+                        currentHeaders = addAesAuthHeaders(currentHeaders)
+                        currentUri = addAccessTokenIfMissing(currentUri, tokenCache)
+                    }
+
+                    return dataSpec.buildUpon()
+                        .setUri(currentUri)
+                        .setHttpRequestHeaders(currentHeaders)
+                        .build()
+                }
+
+                private fun captureAndStripTransientToken(
+                    uri: Uri,
+                    tokenCache: java.util.concurrent.ConcurrentHashMap<String, String>
+                ): Uri {
+                    val token = uri.getQueryParameter("tp_token") ?: return uri
+                    val assetId = getAssetIdFromUri(uri)
+                    if (assetId.isNotEmpty()) {
+                        tokenCache[assetId] = token
+                    }
+
+                    val newUriBuilder = uri.buildUpon().clearQuery()
+                    uri.queryParameterNames.forEach { name ->
+                        if (name != "tp_token") {
+                            uri.getQueryParameters(name).forEach { value ->
+                                newUriBuilder.appendQueryParameter(name, value)
+                            }
+                        }
+                    }
+                    return newUriBuilder.build()
+                }
+
+                private fun addAesAuthHeaders(headers: MutableMap<String, String>): MutableMap<String, String> {
+                    val authHeaders = TPStreamsSDK.getAuthHeaders()
+                    if (authHeaders.isNotEmpty()) {
+                        headers.putAll(authHeaders)
+                    }
+                    return headers
+                }
+
+                private fun addAccessTokenIfMissing(
+                    uri: Uri,
+                    tokenCache: java.util.concurrent.ConcurrentHashMap<String, String>
+                ): Uri {
+                    if (uri.getQueryParameter("access_token")?.isNotBlank() == true) return uri
+                    val assetId = getAssetIdFromUri(uri)
+                    val accessToken = tokenCache[assetId]
+                    if (accessToken.isNullOrBlank()) return uri
+                    return uri.buildUpon()
+                        .appendQueryParameter("access_token", accessToken)
+                        .build()
+                }
+
+                private fun isAesKeyRequest(uri: Uri): Boolean {
+                    val normalized = uri.toString()
+                    return normalized.contains("encryption_key", ignoreCase = true) ||
+                        normalized.contains("aes_key", ignoreCase = true)
+                }
+
+                private fun getAssetIdFromUri(uri: Uri): String {
+                    // TPStreams and Testpress IDs are characteristically 11 characters long.
+                    // This finds the ID segment anywhere in the path (master, variant, or key URL).
+                    return uri.pathSegments.find { it.length == 11 } ?: ""
+                }
+            }
+        )
         
         notificationHelper = DownloadNotificationHelper(
             appContext,

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/MediaItemUtils.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/MediaItemUtils.kt
@@ -62,37 +62,47 @@ object MediaItemUtils {
             }
         }
 
-        val mediaItem = MediaItem.Builder()
-            .setUri(assetInfo.mediaUrl)
-            .setMediaId(assetId)
-            .apply {
-                val metadata = MediaMetadata.Builder()
-                    .setTitle(title)
-                    .setArtworkUri(if (assetInfo.thumbnailUrl.isNotEmpty()) Uri.parse(assetInfo.thumbnailUrl) else null)
-                    .build()
-                setMediaMetadata(metadata)
-                
-                if (assetInfo.enableDrm) {
-                    val apiService = TPStreamsSDK.apiService
-                    val licenseUrl = apiService.drmLicenseUrl(orgId, assetId, accessToken)
+        val playbackUri = buildPlaybackUri(assetInfo.mediaUrl, assetInfo.isAes, accessToken)
 
-                    val drmConfigBuilder = MediaItem.DrmConfiguration.Builder(C.WIDEVINE_UUID)
-                        .setLicenseUri(licenseUrl)
-                        .setMultiSession(true)
-
-                    val authHeaders = TPStreamsSDK.getAuthHeaders()
-                    if (authHeaders.isNotEmpty()) {
-                        drmConfigBuilder.setLicenseRequestHeaders(authHeaders)
-                    }
-                    setDrmConfiguration(drmConfigBuilder.build())
-                }
-                
-                if (subtitleConfigurations.isNotEmpty()) {
-                    setSubtitleConfigurations(subtitleConfigurations)
-                }
-            }
+        val metadata = MediaMetadata.Builder()
+            .setTitle(title)
+            .setArtworkUri(if (assetInfo.thumbnailUrl.isNotEmpty()) Uri.parse(assetInfo.thumbnailUrl) else null)
             .build()
+
+        val builder = MediaItem.Builder()
+            .setUri(playbackUri)
+            .setMediaId(assetId)
+            .setMediaMetadata(metadata)
+
+        if (assetInfo.enableDrm) {
+            val apiService = TPStreamsSDK.apiService
+            val licenseUrl = apiService.drmLicenseUrl(orgId, assetId, accessToken)
+
+            val drmConfigBuilder = MediaItem.DrmConfiguration.Builder(C.WIDEVINE_UUID)
+                .setLicenseUri(licenseUrl)
+                .setMultiSession(true)
+
+            val authHeaders = TPStreamsSDK.getAuthHeaders()
+            if (authHeaders.isNotEmpty()) {
+                drmConfigBuilder.setLicenseRequestHeaders(authHeaders)
+            }
+            builder.setDrmConfiguration(drmConfigBuilder.build())
+        }
+
+        if (subtitleConfigurations.isNotEmpty()) {
+            builder.setSubtitleConfigurations(subtitleConfigurations)
+        }
+
+        val mediaItem = builder.build()
             
         return MediaItemResult(mediaItem, subtitleMetadata)
+    }
+
+    private fun buildPlaybackUri(mediaUrl: String, isAes: Boolean, accessToken: String): Uri {
+        val baseUri = Uri.parse(mediaUrl)
+        if (!isAes || accessToken.isBlank()) return baseUri
+        return baseUri.buildUpon()
+            .appendQueryParameter("tp_token", accessToken)
+            .build()
     }
 }


### PR DESCRIPTION
- Integrated ResolvingDataSource to properly authenticate AES decryption key requests, to prevent AES Playback failures
- Refactored API service to handle optional access tokens across all playback flows.- This prevents 404 errors when starting playback for AES-protected videos.