### PR TITLE
fix: Resolve ExoTimeoutException during fullscreen transitions

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/FullscreenMode.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/FullscreenMode.kt
@@ -30,7 +30,7 @@ class FullscreenMode(private val view: TPStreamsPlayerView) {
     
     private fun moveToDecorView(activity: ComponentActivity) {
         val decorView = activity.window.decorView as ViewGroup
-        val contentView = decorView.findViewById<ViewGroup>(android.R.id.content) ?: return
+        val contentView = decorView.findViewById<ViewGroup>(android.R.id.content)
     
         originalParent = view.parent as? ViewGroup
         originalLayoutParams = view.layoutParams
@@ -38,7 +38,7 @@ class FullscreenMode(private val view: TPStreamsPlayerView) {
         originalParent?.removeView(view)
         view.setBackgroundColor(Color.BLACK)
     
-        contentView.addView(
+        contentView?.addView(
             view,
             ViewGroup.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
@@ -85,8 +85,8 @@ class FullscreenMode(private val view: TPStreamsPlayerView) {
 
     private fun restoreOriginalView(activity: ComponentActivity) {
         val decorView = activity.window.decorView as ViewGroup
-        val contentView = decorView.findViewById<ViewGroup>(android.R.id.content) ?: return
-        contentView.removeView(view)
+        val contentView = decorView.findViewById<ViewGroup>(android.R.id.content)
+        contentView?.removeView(view)
         originalParent?.addView(view, originalLayoutParams)
     }
 

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/FullscreenMode.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/FullscreenMode.kt
@@ -30,6 +30,7 @@ class FullscreenMode(private val view: TPStreamsPlayerView) {
     
     private fun moveToDecorView(activity: ComponentActivity) {
         val decorView = activity.window.decorView as ViewGroup
+        val contentView = decorView.findViewById<ViewGroup>(android.R.id.content) ?: return
     
         originalParent = view.parent as? ViewGroup
         originalLayoutParams = view.layoutParams
@@ -37,7 +38,7 @@ class FullscreenMode(private val view: TPStreamsPlayerView) {
         originalParent?.removeView(view)
         view.setBackgroundColor(Color.BLACK)
     
-        decorView.addView(
+        contentView.addView(
             view,
             ViewGroup.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
@@ -84,7 +85,8 @@ class FullscreenMode(private val view: TPStreamsPlayerView) {
 
     private fun restoreOriginalView(activity: ComponentActivity) {
         val decorView = activity.window.decorView as ViewGroup
-        decorView.removeView(view)
+        val contentView = decorView.findViewById<ViewGroup>(android.R.id.content) ?: return
+        contentView.removeView(view)
         originalParent?.addView(view, originalLayoutParams)
     }
 

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/FullscreenMode.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/FullscreenMode.kt
@@ -19,8 +19,13 @@ class FullscreenMode(private val view: TPStreamsPlayerView) {
         val activity = view.getActivity() as? ComponentActivity ?: return
         if (isFullscreen) return
     
+        val player = view.getPlayer()
         view.lifecycleManager?.preservePlaybackStateAcrossTransition {
+            view.setPlayer(null)
             moveToDecorView(activity)
+            if (player != null) {
+                view.setPlayer(player)
+            }
             switchToLandscape(activity)
             hideSystemUI(activity)
             updateFullscreenState()
@@ -30,7 +35,6 @@ class FullscreenMode(private val view: TPStreamsPlayerView) {
     
     private fun moveToDecorView(activity: ComponentActivity) {
         val decorView = activity.window.decorView as ViewGroup
-        val contentView = decorView.findViewById<ViewGroup>(android.R.id.content)
     
         originalParent = view.parent as? ViewGroup
         originalLayoutParams = view.layoutParams
@@ -38,7 +42,7 @@ class FullscreenMode(private val view: TPStreamsPlayerView) {
         originalParent?.removeView(view)
         view.setBackgroundColor(Color.BLACK)
     
-        contentView?.addView(
+        decorView.addView(
             view,
             ViewGroup.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
@@ -74,8 +78,13 @@ class FullscreenMode(private val view: TPStreamsPlayerView) {
         val activity = view.getActivity() as? ComponentActivity ?: return
         if (!isFullscreen) return
 
+        val player = view.getPlayer()
         view.lifecycleManager?.preservePlaybackStateAcrossTransition {
+            view.setPlayer(null)
             restoreOriginalView(activity)
+            if (player != null) {
+                view.setPlayer(player)
+            }
             switchToPortrait(activity)
             showSystemUI(activity)
             clearBackPressHandler()
@@ -85,8 +94,7 @@ class FullscreenMode(private val view: TPStreamsPlayerView) {
 
     private fun restoreOriginalView(activity: ComponentActivity) {
         val decorView = activity.window.decorView as ViewGroup
-        val contentView = decorView.findViewById<ViewGroup>(android.R.id.content)
-        contentView?.removeView(view)
+        decorView.removeView(view)
         originalParent?.addView(view, originalLayoutParams)
     }
 

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
@@ -21,7 +21,7 @@ import com.tpstreams.player.R
 class TPStreamsPlayerView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
-    defStyleAttr: Int = R.style.TPStreamsPlayerView
+    defStyleAttr: Int = 0
 ) : PlayerView(context, attrs, defStyleAttr), 
     PlayerSettingsBottomSheet.SettingsListener, 
     QualityOptionsBottomSheet.QualityOptionsListener,

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
@@ -352,6 +352,7 @@ class TPStreamsPlayerView @JvmOverloads constructor(
             PlaybackHistoryManager.recordLog(message)
         }
         
+        unregisterFromLifecycle()
         lifecycleManager = player?.let { PlayerLifecycleManager(it) }
         registerWithLifecycle()
         

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
@@ -21,7 +21,7 @@ import com.tpstreams.player.R
 class TPStreamsPlayerView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
-    defStyleAttr: Int = 0
+    defStyleAttr: Int = R.style.TPStreamsPlayerView
 ) : PlayerView(context, attrs, defStyleAttr), 
     PlayerSettingsBottomSheet.SettingsListener, 
     QualityOptionsBottomSheet.QualityOptionsListener,

--- a/tpstreams-android-player/src/main/res/values/styles.xml
+++ b/tpstreams-android-player/src/main/res/values/styles.xml
@@ -51,4 +51,8 @@
         <item name="android:paddingStart">@dimen/timer_text_padding</item>
         <item name="android:paddingLeft">@dimen/timer_text_padding</item>
     </style>
+
+    <style name="TPStreamsPlayerView" parent="">
+        <item name="surface_type">texture_view</item>
+    </style>
 </resources> 

--- a/tpstreams-android-player/src/main/res/values/styles.xml
+++ b/tpstreams-android-player/src/main/res/values/styles.xml
@@ -51,5 +51,4 @@
         <item name="android:paddingStart">@dimen/timer_text_padding</item>
         <item name="android:paddingLeft">@dimen/timer_text_padding</item>
     </style>
-
 </resources> 

--- a/tpstreams-android-player/src/main/res/values/styles.xml
+++ b/tpstreams-android-player/src/main/res/values/styles.xml
@@ -52,7 +52,4 @@
         <item name="android:paddingLeft">@dimen/timer_text_padding</item>
     </style>
 
-    <style name="TPStreamsPlayerView" parent="">
-        <item name="surface_type">texture_view</item>
-    </style>
 </resources> 


### PR DESCRIPTION
- Player crashed during fullscreen transitions with "Detaching surface timed out."
- Reparenting the player view between containers while the player was still attached caused a SurfaceView detach race in ExoPlayer
- Detach the player before moving the view, then reattach it after the reparent so ExoPlayer can release the surface cleanly
