### PR TITLE
fix: prevent fullscreen loading spinner on player reattach

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
@@ -358,8 +358,20 @@ class TPStreamsPlayerView @JvmOverloads constructor(
         
         if (player != null) {
             when (player.playbackState) {
-                Player.STATE_IDLE, Player.STATE_BUFFERING -> showLoading()
-                Player.STATE_READY, Player.STATE_ENDED -> hideLoading()
+                Player.STATE_IDLE -> {
+                    showLoading()
+                }
+                Player.STATE_BUFFERING -> {
+                    showLoading()
+                    hideErrorMessage()
+                }
+                Player.STATE_READY -> {
+                    hideLoading()
+                    hideErrorMessage()
+                }
+                Player.STATE_ENDED -> {
+                    hideLoading()
+                }
             }
             player.addListener(playbackStateListener)
             

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
@@ -357,7 +357,10 @@ class TPStreamsPlayerView @JvmOverloads constructor(
         registerWithLifecycle()
         
         if (player != null) {
-            showLoading()
+            when (player.playbackState) {
+                Player.STATE_IDLE, Player.STATE_BUFFERING -> showLoading()
+                Player.STATE_READY, Player.STATE_ENDED -> hideLoading()
+            }
             player.addListener(playbackStateListener)
             
             if (player is TPStreamsPlayer) {


### PR DESCRIPTION
- Entering fullscreen reattaches the player view, but the view was always showing the loading overlay even when playback was already in READY state.
- That made fullscreen briefly look like a reload and left the spinner visible until a later pause/play event.
- This change makes the loading UI state-aware during reattachment so READY and ENDED hide loading immediately, while IDLE and BUFFERING still show it.