### PR TITLE
feat: Add public API to control auto-fullscreen on rotation

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
@@ -39,7 +39,8 @@ class TPStreamsPlayerView @JvmOverloads constructor(
     
     private var playerControlView: TPStreamsPlayerControlView? = null
     private var orientationEventListener: OrientationListener? = null
-    private var autoFullscreenEnabled = true
+    private var autoFullscreenOnRotateEnabled = true
+    private var autoFullscreenEnabled = false
     var lifecycleManager: PlayerLifecycleManager? = null
     
     private var errorOverlay: View? = null
@@ -171,7 +172,7 @@ class TPStreamsPlayerView @JvmOverloads constructor(
         ensureErrorOverlaySetup()
         
         post {
-            if (autoFullscreenEnabled) {
+            if (autoFullscreenOnRotateEnabled) {
                 enableAutoFullscreenOnRotate()
             }
             registerWithLifecycle()
@@ -179,7 +180,8 @@ class TPStreamsPlayerView @JvmOverloads constructor(
     }
 
     fun setAutoFullscreenOnRotateEnabled(enabled: Boolean) {
-        if (autoFullscreenEnabled == enabled) return
+        if (autoFullscreenOnRotateEnabled == enabled) return
+        autoFullscreenOnRotateEnabled = enabled
         if (enabled) {
             enableAutoFullscreenOnRotate()
         } else {
@@ -305,7 +307,7 @@ class TPStreamsPlayerView @JvmOverloads constructor(
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
         
-        if (autoFullscreenEnabled) {
+        if (autoFullscreenOnRotateEnabled && !autoFullscreenEnabled) {
             val wasPlayingBefore = player?.isPlaying ?: false
             
             lifecycleManager?.setInTransition(true)

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
@@ -39,7 +39,7 @@ class TPStreamsPlayerView @JvmOverloads constructor(
     
     private var playerControlView: TPStreamsPlayerControlView? = null
     private var orientationEventListener: OrientationListener? = null
-    private var autoFullscreenEnabled = false
+    private var autoFullscreenEnabled = true
     var lifecycleManager: PlayerLifecycleManager? = null
     
     private var errorOverlay: View? = null
@@ -171,8 +171,18 @@ class TPStreamsPlayerView @JvmOverloads constructor(
         ensureErrorOverlaySetup()
         
         post {
-            enableAutoFullscreenOnRotate()
+            if (autoFullscreenEnabled) {
+                enableAutoFullscreenOnRotate()
+            }
             registerWithLifecycle()
+        }
+    }
+
+    fun setAutoFullscreenOnRotateEnabled(enabled: Boolean) {
+        if (enabled) {
+            enableAutoFullscreenOnRotate()
+        } else {
+            disableAutoFullscreenOnRotate()
         }
     }
 

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
@@ -179,6 +179,7 @@ class TPStreamsPlayerView @JvmOverloads constructor(
     }
 
     fun setAutoFullscreenOnRotateEnabled(enabled: Boolean) {
+        if (autoFullscreenEnabled == enabled) return
         if (enabled) {
             enableAutoFullscreenOnRotate()
         } else {
@@ -304,7 +305,7 @@ class TPStreamsPlayerView @JvmOverloads constructor(
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
         
-        if (!autoFullscreenEnabled) {
+        if (autoFullscreenEnabled) {
             val wasPlayingBefore = player?.isPlaying ?: false
             
             lifecycleManager?.setInTransition(true)


### PR DESCRIPTION
- Android did not provide control over auto-fullscreen behavior during device rotation.
- Auto fullscreen transitions were internally handled without any public configuration API.
- Added a public API to enable or disable auto-fullscreen on rotation