### PR TITLE
fix: Handle live stream pause gracefully by suppressing PlaylistStuckException

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -245,6 +245,13 @@ private constructor(
                     return
                 }
 
+                if (isPlaylistStuckException(error)) {
+                    // This error is raised when the HLS playlist stops advancing (e.g., the live stream is paused).
+                    // We safely suppress this error so the player naturally shows the buffering spinner instead of crashing.
+                    // Playback can resume once the stream starts advancing again or the user seeks to a previous duration.
+                    return
+                }
+
                 if (isNetworkError(error)) {
                      networkRecoveryHandler.startMonitoring { retryPlayback() }
                 }
@@ -287,6 +294,17 @@ private constructor(
                error.errorCode == PlaybackException.ERROR_CODE_DRM_DISALLOWED_OPERATION ||
                 error.errorCode == PlaybackException.ERROR_CODE_DRM_SYSTEM_ERROR ||
                 cause is MediaCodec.CryptoException
+    }
+
+    private fun isPlaylistStuckException(error: PlaybackException): Boolean {
+        var cause: Throwable? = error.cause
+        while (cause != null) {
+            if (cause is androidx.media3.exoplayer.hls.playlist.HlsPlaylistTracker.PlaylistStuckException) {
+                return true
+            }
+            cause = cause.cause
+        }
+        return false
     }
 
     private fun fetchAndPrepare(assetId: String, accessToken: String) {

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -296,6 +296,7 @@ private constructor(
                 cause is MediaCodec.CryptoException
     }
 
+    @OptIn(androidx.media3.common.util.UnstableApi::class)
     private fun isPlaylistStuckException(error: PlaybackException): Boolean {
         var cause: Throwable? = error.cause
         while (cause != null) {
@@ -438,6 +439,9 @@ private constructor(
 
     override fun play() {
         if (isPrepared) {
+            if (exoPlayer.playbackState == Player.STATE_IDLE) {
+                exoPlayer.prepare()
+            }
             exoPlayer.play()
         } else {
             requestedPlay = true


### PR DESCRIPTION
- When an HLS live stream is paused, ExoPlayer's internal downloader panics when the playlist stops advancing and throws a PlaylistStuckException. Since a paused stream is a valid status and not a critical failure, we need to prevent this exception from crashing the player.

**Architectural Decision:**
We initially attempted to use ExoPlayer's official `LoadErrorHandlingPolicy` to handle network retries for the stuck manifest. However, we found that ExoPlayer's internal error wrapping is unpredictable, causing the exception to leak through the policy and stil. Furthermore, the policy approach required significant boilerplate and altered the player initialization signature.

Instead, we opted to intercept `PlaylistStuckException` at the bottom of the funnel directly inside the global `onPlayerError` callback. 

Why this approach:
1. It guarantees the exception is caught and swallowed regardless of how deeply Media3 wraps it internally.
2. It prevents unnecessary Sentry logging and generic UI error overlays.
3. It keeps `createExoPlayer` clean and avoids invasive boilerplate configuration.
4. It allows the player to fall asleep safely (enter an IDLE state).