### PR TITLE
fix: Include request URLs in Sentry error reports

### DIFF
--- a/app/src/main/java/com/tpstreams/player/MainActivity.kt
+++ b/app/src/main/java/com/tpstreams/player/MainActivity.kt
@@ -134,7 +134,7 @@ class MainActivity : AppCompatActivity() {
         // TPStreams Tab Buttons
         findViewById<View>(R.id.btn_drm_video).setOnClickListener {
             val intent = Intent(this, PlayerActivity::class.java).apply {
-                putExtra(EXTRA_ASSET_ID, "42h2tfmNf")
+                putExtra(EXTRA_ASSET_ID, "42h2tZ5fmNf")
                 putExtra(EXTRA_ACCESS_TOKEN, "9327e2d0-fa13-4288-902d-840f32cd0eed")
             }
             startActivity(intent)

--- a/app/src/main/java/com/tpstreams/player/MainActivity.kt
+++ b/app/src/main/java/com/tpstreams/player/MainActivity.kt
@@ -134,7 +134,7 @@ class MainActivity : AppCompatActivity() {
         // TPStreams Tab Buttons
         findViewById<View>(R.id.btn_drm_video).setOnClickListener {
             val intent = Intent(this, PlayerActivity::class.java).apply {
-                putExtra(EXTRA_ASSET_ID, "42h2tZ5fmNf")
+                putExtra(EXTRA_ASSET_ID, "42h2tfmNf")
                 putExtra(EXTRA_ACCESS_TOKEN, "9327e2d0-fa13-4288-902d-840f32cd0eed")
             }
             startActivity(intent)

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -87,6 +87,7 @@ private constructor(
     }
 
     private var isPrepared = false
+    private var drmLicenseUrl: String? = null
     private var requestedPlay = false
     private var hasSeekedToStartAt = false
     private var subtitleMetadata = mapOf<String, Boolean>()
@@ -258,7 +259,7 @@ private constructor(
                 
                 debugLog("Player ERROR - ${error.errorCodeName}")
                 val errorPlayerId = SentryLogger.generatePlayerIdString()
-                SentryLogger.logPlaybackException(error, assetId, errorPlayerId)
+                SentryLogger.logPlaybackException(error, assetId, errorPlayerId, drmLicenseUrl)
                 
                 val errorType = error.toError()
                 val errorMessage = error.getErrorMessage(errorPlayerId)
@@ -335,6 +336,7 @@ private constructor(
         onLiveStreamStatusChanged?.invoke(_isLiveStream)
 
         val result = MediaItemUtils.buildMediaItem(assetInfo, assetInfo.title, orgId, assetId, accessToken)
+        drmLicenseUrl = result.drmLicenseUrl
         setSubtitleMetadata(result.subtitleMetadata)
 
         playerScope.launch(Dispatchers.Main) {

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/data/AssetRepository.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/data/AssetRepository.kt
@@ -38,17 +38,15 @@ object AssetRepository {
         CoroutineScope(Dispatchers.IO).launch {
             try {
                 val assetApiUrl = apiService.assetInfoUrl(orgId, assetId, accessToken)
-                var requestUrl = assetApiUrl
                 val requestBuilder = Request.Builder().url(assetApiUrl)
                 TPStreamsSDK.getAuthHeaders().forEach { (name, value) ->
                     requestBuilder.addHeader(name, value)
                 }
                 val request = requestBuilder.build()
-                requestUrl = request.url.toString()
                 val response = client.newCall(request).execute()
 
                 if (!response.isSuccessful) {
-                    handleApiError(assetId, response.code, requestUrl, callback)
+                    handleApiError(assetId, response.code, assetApiUrl, callback)
                     return@launch
                 }
 
@@ -66,7 +64,8 @@ object AssetRepository {
                     callback.onSuccess(assetInfo)
                 }
             } catch (e: Exception) {
-                handleException(assetId, e, requestUrl, callback)
+                val url = runCatching { apiService.assetInfoUrl(orgId, assetId, accessToken) }.getOrNull() ?: ""
+                handleException(assetId, e, url, callback)
             }
         }
     }

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/data/AssetRepository.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/data/AssetRepository.kt
@@ -38,15 +38,17 @@ object AssetRepository {
         CoroutineScope(Dispatchers.IO).launch {
             try {
                 val assetApiUrl = apiService.assetInfoUrl(orgId, assetId, accessToken)
+                var requestUrl = assetApiUrl
                 val requestBuilder = Request.Builder().url(assetApiUrl)
                 TPStreamsSDK.getAuthHeaders().forEach { (name, value) ->
                     requestBuilder.addHeader(name, value)
                 }
                 val request = requestBuilder.build()
+                requestUrl = request.url.toString()
                 val response = client.newCall(request).execute()
 
                 if (!response.isSuccessful) {
-                    handleApiError(assetId, response.code, callback)
+                    handleApiError(assetId, response.code, requestUrl, callback)
                     return@launch
                 }
 
@@ -64,7 +66,7 @@ object AssetRepository {
                     callback.onSuccess(assetInfo)
                 }
             } catch (e: Exception) {
-                handleException(assetId, e, callback)
+                handleException(assetId, e, requestUrl, callback)
             }
         }
     }
@@ -77,9 +79,9 @@ object AssetRepository {
         fetchAssetInfo(TPStreamsSDK.requireOrgId(), assetId, accessToken, callback)
     }
 
-    private fun handleApiError(assetId: String, code: Int, callback: AssetCallback) {
+    private fun handleApiError(assetId: String, code: Int, url: String, callback: AssetCallback) {
         val errorPlayerId = SentryLogger.generatePlayerIdString()
-        SentryLogger.logAPIException(Exception("API request failed with code: $code"), assetId, code, errorPlayerId)
+        SentryLogger.logAPIException(Exception("API request failed with code: $code"), assetId, code, errorPlayerId, url)
 
         val errorType = when (code) {
             404 -> PlaybackError.INVALID_ASSETS_ID
@@ -93,9 +95,9 @@ object AssetRepository {
         }
     }
 
-    private fun handleException(assetId: String, e: Exception, callback: AssetCallback) {
+    private fun handleException(assetId: String, e: Exception, url: String, callback: AssetCallback) {
         val errorPlayerId = SentryLogger.generatePlayerIdString()
-        SentryLogger.logAPIException(e, assetId, null, errorPlayerId)
+        SentryLogger.logAPIException(e, assetId, null, errorPlayerId, url)
 
         val errorType = e.toPlaybackError()
         val errorMessage = e.getErrorMessage(errorPlayerId, null)

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/MediaItemUtils.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/MediaItemUtils.kt
@@ -16,7 +16,8 @@ object MediaItemUtils {
 
     data class MediaItemResult(
         val mediaItem: MediaItem,
-        val subtitleMetadata: Map<String, Boolean>
+        val subtitleMetadata: Map<String, Boolean>,
+        val drmLicenseUrl: String? = null
     )
 
     fun buildMediaItem(
@@ -74,9 +75,11 @@ object MediaItemUtils {
             .setMediaId(assetId)
             .setMediaMetadata(metadata)
 
+        val drmLicenseUrl: String?
         if (assetInfo.enableDrm) {
             val apiService = TPStreamsSDK.apiService
             val licenseUrl = apiService.drmLicenseUrl(orgId, assetId, accessToken)
+            drmLicenseUrl = licenseUrl
 
             val drmConfigBuilder = MediaItem.DrmConfiguration.Builder(C.WIDEVINE_UUID)
                 .setLicenseUri(licenseUrl)
@@ -87,6 +90,8 @@ object MediaItemUtils {
                 drmConfigBuilder.setLicenseRequestHeaders(authHeaders)
             }
             builder.setDrmConfiguration(drmConfigBuilder.build())
+        } else {
+            drmLicenseUrl = null
         }
 
         if (subtitleConfigurations.isNotEmpty()) {
@@ -95,7 +100,7 @@ object MediaItemUtils {
 
         val mediaItem = builder.build()
             
-        return MediaItemResult(mediaItem, subtitleMetadata)
+        return MediaItemResult(mediaItem, subtitleMetadata, drmLicenseUrl)
     }
 
     private fun buildPlaybackUri(mediaUrl: String, isAes: Boolean, accessToken: String): Uri {

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/SentryLogger.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/SentryLogger.kt
@@ -45,7 +45,8 @@ internal object SentryLogger {
         exception: Exception,
         assetId: String?,
         responseCode: Int?,
-        playerId: String
+        playerId: String,
+        url: String? = null
     ) {
         Sentry.captureException(exception) { scope ->
             val nowEpochMs = System.currentTimeMillis()
@@ -56,12 +57,14 @@ internal object SentryLogger {
             scope.setTag("playerId", playerId)
             assetId?.let { scope.setTag("assetId", it) }
             responseCode?.let { scope.setTag("responseCode", it.toString()) }
+            url?.takeIf { it.isNotEmpty() }?.let { scope.setTag("requestUrl", it) }
             scope.setContexts(
                 "TPStreamsPlayer",
                 mapOf(
                     "Asset ID" to (assetId ?: "N/A"),
                     "Player ID" to playerId,
-                    "Response Code" to (responseCode ?: "N/A")
+                    "Response Code" to (responseCode ?: "N/A"),
+                    "Request URL" to (url?.takeIf { it.isNotEmpty() } ?: "N/A")
                 )
             )
         }

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/SentryLogger.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/SentryLogger.kt
@@ -15,7 +15,8 @@ internal object SentryLogger {
     fun logPlaybackException(
         error: PlaybackException,
         assetId: String?,
-        playerId: String
+        playerId: String,
+        drmLicenseUrl: String? = null
     ) {
         Sentry.captureException(error) { scope ->
             val nowEpochMs = System.currentTimeMillis()
@@ -25,13 +26,15 @@ internal object SentryLogger {
             scope.setContexts("Clock Drift", ClockDriftDiagnostics.buildSentryClockContext(nowEpochMs))
             scope.setTag("playerId", playerId)
             assetId?.let { scope.setTag("assetId", it) }
+            drmLicenseUrl?.takeIf { it.isNotEmpty() }?.let { scope.setTag("drmLicenseUrl", it) }
             scope.setContexts(
                 "TPStreamsPlayer",
                 mapOf(
                     "Error Code" to error.errorCode,
                     "Error Code Name" to error.errorCodeName,
                     "Asset ID" to (assetId ?: "N/A"),
-                    "Player ID" to playerId
+                    "Player ID" to playerId,
+                    "DRM License URL" to (drmLicenseUrl?.takeIf { it.isNotEmpty() } ?: "N/A")
                 )
             )
             scope.setContexts(


### PR DESCRIPTION
- Asset loading failures were difficult to investigate because error reports did not include the exact request URL that failed.
- This made it harder to identify issues caused by invalid request parameters, expired access tokens, or incorrect endpoint generation.
- Asset API failures now include the request URL in error reports, providing additional context to diagnose playback and asset loading issues more effectively.