### PR TITLE
fix: Return Sentry event ID from logPlaybackException

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/SentryLogger.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/SentryLogger.kt
@@ -17,8 +17,8 @@ internal object SentryLogger {
         assetId: String?,
         playerId: String,
         drmLicenseUrl: String? = null
-    ) {
-        Sentry.captureException(error) { scope ->
+    ): String? {
+        return Sentry.captureException(error) { scope ->
             val nowEpochMs = System.currentTimeMillis()
             ClockDriftDiagnostics.buildSentryClockTags(nowEpochMs).forEach { (key, value) ->
                 scope.setTag(key, value)
@@ -50,8 +50,8 @@ internal object SentryLogger {
         responseCode: Int?,
         playerId: String,
         url: String? = null
-    ) {
-        Sentry.captureException(exception) { scope ->
+    ): String? {
+        return Sentry.captureException(exception) { scope ->
             val nowEpochMs = System.currentTimeMillis()
             ClockDriftDiagnostics.buildSentryClockTags(nowEpochMs).forEach { (key, value) ->
                 scope.setTag(key, value)


### PR DESCRIPTION
logPlaybackException had a block body ({ }) which returned Unit, even though it called ?.toString() on the Sentry capture result. This caused a compile error in NetworkDiagnosticsManager.sendSentryEvent which expected a String? return from this method.

Switched from block body to expression body (=) so the ?.toString() result is actually returned as String?.