### PR TITLE
feat: support maximum playback resolution limits

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -16,7 +16,6 @@ jobs:
       github.actor != 'claude[bot]' &&
       github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
-
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -16,6 +16,7 @@ jobs:
       github.actor != 'claude[bot]' &&
       github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
+
     permissions:
       contents: write
       pull-requests: write

--- a/app/src/main/java/com/tpstreams/player/PlayerActivity.kt
+++ b/app/src/main/java/com/tpstreams/player/PlayerActivity.kt
@@ -24,6 +24,7 @@ class PlayerActivity : AppCompatActivity() {
         val isTestpress = intent.getBooleanExtra(MainActivity.EXTRA_IS_TESTPRESS, false)
 
         viewModel.initPlayer(assetId, accessToken, isTestpress)
+        viewModel.player?.setMaxResolution(1080)
         binding.playerView.player = viewModel.player
     }
 }

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/SettingsPanel.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/SettingsPanel.kt
@@ -24,7 +24,7 @@ class SettingsPanel(private val view: TPStreamsPlayerView) {
         // If the user's selected resolution is no longer available
         // (e.g., maxAllowedResolution was lowered via setMaxResolution),
         // fall back to Auto so the UI doesn't show a stale label.
-        if (currentQuality.contains("p") && !resolutionStrings.contains(currentQuality)) {
+        if (currentQuality.matches(Regex("\\d+p")) && !resolutionStrings.contains(currentQuality)) {
             setCurrentQuality(QualityOptionsBottomSheet.QUALITY_AUTO)
         }
     }

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/SettingsPanel.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/SettingsPanel.kt
@@ -20,6 +20,13 @@ class SettingsPanel(private val view: TPStreamsPlayerView) {
         val availableHeights = tpsPlayer.getAvailableVideoResolutions()
         val resolutionStrings = availableHeights.map { "${it}p" }
         setAvailableResolutions(resolutionStrings)
+
+        // If the user's selected resolution is no longer available
+        // (e.g., maxAllowedResolution was lowered via setMaxResolution),
+        // fall back to Auto so the UI doesn't show a stale label.
+        if (currentQuality.contains("p") && !resolutionStrings.contains(currentQuality)) {
+            setCurrentQuality(QualityOptionsBottomSheet.QUALITY_AUTO)
+        }
     }
     
     fun setAvailableResolutions(resolutions: List<String>) {

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/SettingsPanel.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/SettingsPanel.kt
@@ -70,7 +70,7 @@ class SettingsPanel(private val view: TPStreamsPlayerView) {
         // Get the highest available resolution
         val highestResolution = availableResolutions.firstOrNull()?.dropLast(1)?.toIntOrNull()
         if (highestResolution != null) {
-            view.getPlayer()?.setVideoResolution(highestResolution)
+            view.getPlayer()?.setMaxResolution(highestResolution)
         } else {
             onAutoQualitySelected()
         }
@@ -82,7 +82,7 @@ class SettingsPanel(private val view: TPStreamsPlayerView) {
         // Get the lowest available resolution
         val lowestResolution = availableResolutions.lastOrNull()?.dropLast(1)?.toIntOrNull()
         if (lowestResolution != null) {
-            view.getPlayer()?.setVideoResolution(lowestResolution)
+            view.getPlayer()?.setMaxResolution(lowestResolution)
         } else {
             onAutoQualitySelected()
         }
@@ -108,7 +108,7 @@ class SettingsPanel(private val view: TPStreamsPlayerView) {
     
         val height = resolution.dropLast(1).toIntOrNull()
         if (height != null) {
-            view.getPlayer()?.setVideoResolution(height)
+            view.getPlayer()?.setMaxResolution(height)
         }
     }
     

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/SettingsPanel.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/SettingsPanel.kt
@@ -56,12 +56,7 @@ class SettingsPanel(private val view: TPStreamsPlayerView) {
     fun onAutoQualitySelected() {
         setCurrentQuality(QualityOptionsBottomSheet.QUALITY_AUTO)
     
-        // Let the trackSelector handle it automatically (no constraints)
-        val player = view.getPlayer()
-        val params = player?.getTrackSelector()?.buildUponParameters()
-            ?.clearVideoSizeConstraints()
-            ?.build()
-        if (params != null) player.getTrackSelector().parameters = params
+        view.getPlayer()?.setUserResolutionPreference(Int.MAX_VALUE)
     }
     
     fun onHigherQualitySelected() {
@@ -70,7 +65,7 @@ class SettingsPanel(private val view: TPStreamsPlayerView) {
         // Get the highest available resolution
         val highestResolution = availableResolutions.firstOrNull()?.dropLast(1)?.toIntOrNull()
         if (highestResolution != null) {
-            view.getPlayer()?.setMaxResolution(highestResolution)
+            view.getPlayer()?.setUserResolutionPreference(highestResolution)
         } else {
             onAutoQualitySelected()
         }
@@ -82,7 +77,7 @@ class SettingsPanel(private val view: TPStreamsPlayerView) {
         // Get the lowest available resolution
         val lowestResolution = availableResolutions.lastOrNull()?.dropLast(1)?.toIntOrNull()
         if (lowestResolution != null) {
-            view.getPlayer()?.setMaxResolution(lowestResolution)
+            view.getPlayer()?.setUserResolutionPreference(lowestResolution)
         } else {
             onAutoQualitySelected()
         }
@@ -108,7 +103,7 @@ class SettingsPanel(private val view: TPStreamsPlayerView) {
     
         val height = resolution.dropLast(1).toIntOrNull()
         if (height != null) {
-            view.getPlayer()?.setMaxResolution(height)
+            view.getPlayer()?.setUserResolutionPreference(height)
         }
     }
     

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -602,7 +602,7 @@ private constructor(
                     val group = trackGroups.get(groupIndex)
                     for (trackIndex in 0 until group.length) {
                         val format = group.getFormat(trackIndex)
-                        if (format.height != Format.NO_VALUE) {
+                        if (format.height != Format.NO_VALUE && format.height <= maxAllowedResolution) {
                             resolutions.add(format.height)
                         }
                     }
@@ -694,11 +694,34 @@ private constructor(
         }
     }
 
+    private var maxAllowedResolution: Int = Int.MAX_VALUE
+    private var userPreferredResolution: Int = Int.MAX_VALUE
+
     @OptIn(UnstableApi::class)
     fun setMaxResolution(height: Int) {
-        Log.d("TPStreamsPlayer", "Setting max video height to $height")
+        Log.d("TPStreamsPlayer", "Setting hard max video height to $height")
+        maxAllowedResolution = height
+        applyResolutionConstraints()
+    }
+
+    @OptIn(UnstableApi::class)
+    internal fun setUserResolutionPreference(height: Int) {
+        Log.d("TPStreamsPlayer", "User preferred max video height set to $height")
+        userPreferredResolution = height
+        applyResolutionConstraints()
+    }
+
+    @OptIn(UnstableApi::class)
+    private fun applyResolutionConstraints() {
+        val effectiveMax = minOf(maxAllowedResolution, userPreferredResolution)
         val parametersBuilder = trackSelector.buildUponParameters()
-            .setMaxVideoSize(Int.MAX_VALUE, height) // Unlimited width, constrained height
+        
+        if (effectiveMax == Int.MAX_VALUE) {
+            parametersBuilder.clearVideoSizeConstraints()
+        } else {
+            parametersBuilder.setMaxVideoSize(Int.MAX_VALUE, effectiveMax) // Unlimited width, constrained height
+        }
+        
         trackSelector.parameters = parametersBuilder.build()
     }
 

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -695,7 +695,7 @@ private constructor(
     }
 
     @OptIn(UnstableApi::class)
-    fun setVideoResolution(height: Int) {
+    fun setMaxResolution(height: Int) {
         Log.d("TPStreamsPlayer", "Setting max video height to $height")
         val parametersBuilder = trackSelector.buildUponParameters()
             .setMaxVideoSize(Int.MAX_VALUE, height) // Unlimited width, constrained height

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -626,7 +626,7 @@ private constructor(
                     val group = trackGroups.get(groupIndex)
                     for (trackIndex in 0 until group.length) {
                         val format = group.getFormat(trackIndex)
-                        if (format.height != Format.NO_VALUE && format.bitrate != Format.NO_VALUE) {
+                        if (format.height != Format.NO_VALUE && format.bitrate != Format.NO_VALUE && format.height <= maxAllowedResolution) {
                             // Store the resolution and its corresponding bitrate
                             resolutionBitrateMap[format.height] = format.bitrate
                         }


### PR DESCRIPTION
- Allow apps to enforce a maximum playback resolution.
- Ensure manual and automatic quality selection respect the configured limit.
- Separate app-defined limits from user quality preference for consistent resolution selection.