### PR TITLE
feat: Add setVideoResolution to TPStreamsPlayerView

### DIFF
--- a/app/src/main/java/com/tpstreams/player/PlayerActivity.kt
+++ b/app/src/main/java/com/tpstreams/player/PlayerActivity.kt
@@ -25,6 +25,7 @@ class PlayerActivity : AppCompatActivity() {
 
         viewModel.initPlayer(assetId, accessToken, isTestpress)
         viewModel.player?.setMaxResolution(1080)
+        binding.playerView.setVideoResolution(720)
         binding.playerView.player = viewModel.player
     }
 }

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/SettingsPanel.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/SettingsPanel.kt
@@ -7,6 +7,7 @@ class SettingsPanel(private val view: TPStreamsPlayerView) {
     private var currentQuality: String = QualityOptionsBottomSheet.QUALITY_AUTO
     private var availableResolutions: List<String> = emptyList()
     private var currentPlaybackSpeed: Float = 1.0f
+    private var pendingResolutionHeight: Int? = null
 
     fun showSettings() {
         val activity = view.getActivity()
@@ -105,12 +106,25 @@ class SettingsPanel(private val view: TPStreamsPlayerView) {
         view.playbackSpeedBottomSheet.show(activity.supportFragmentManager)
     }
 
+    fun setPreferredResolutionHeight(height: Int) {
+        require(height > 0) { "Resolution height must be positive: $height" }
+        setCurrentQuality("${height}p")
+        pendingResolutionHeight = height
+        view.getPlayer()?.setUserResolutionPreference(height)
+    }
+
     fun onResolutionSelected(resolution: String) {
-        setCurrentQuality(resolution)
-    
-        val height = resolution.dropLast(1).toIntOrNull()
-        if (height != null) {
-            view.getPlayer()?.setUserResolutionPreference(height)
+        val height = resolution.removeSuffix("p").toIntOrNull() ?: return
+        setPreferredResolutionHeight(height)
+    }
+
+    fun applyPendingResolutionPreference() {
+        pendingResolutionHeight?.let { height ->
+            val player = view.getPlayer()
+            if (player != null) {
+                player.setUserResolutionPreference(height)
+                pendingResolutionHeight = null
+            }
         }
     }
     

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/SettingsPanel.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/SettingsPanel.kt
@@ -7,7 +7,7 @@ class SettingsPanel(private val view: TPStreamsPlayerView) {
     private var currentQuality: String = QualityOptionsBottomSheet.QUALITY_AUTO
     private var availableResolutions: List<String> = emptyList()
     private var currentPlaybackSpeed: Float = 1.0f
-    private var pendingResolutionHeight: Int? = null
+    private var preferredResolutionHeight: Int? = null
 
     fun showSettings() {
         val activity = view.getActivity()
@@ -27,6 +27,7 @@ class SettingsPanel(private val view: TPStreamsPlayerView) {
         // fall back to Auto so the UI doesn't show a stale label.
         if (currentQuality.matches(Regex("\\d+p")) && !resolutionStrings.contains(currentQuality)) {
             setCurrentQuality(QualityOptionsBottomSheet.QUALITY_AUTO)
+            preferredResolutionHeight = null
         }
     }
     
@@ -63,13 +64,13 @@ class SettingsPanel(private val view: TPStreamsPlayerView) {
 
     fun onAutoQualitySelected() {
         setCurrentQuality(QualityOptionsBottomSheet.QUALITY_AUTO)
-        pendingResolutionHeight = null
+        preferredResolutionHeight = null
         view.getPlayer()?.setUserResolutionPreference(Int.MAX_VALUE)
     }
     
     fun onHigherQualitySelected() {
         setCurrentQuality(QualityOptionsBottomSheet.QUALITY_HIGHER)
-        pendingResolutionHeight = null
+        preferredResolutionHeight = null
         
         // Get the highest available resolution
         val highestResolution = availableResolutions.firstOrNull()?.dropLast(1)?.toIntOrNull()
@@ -82,7 +83,7 @@ class SettingsPanel(private val view: TPStreamsPlayerView) {
     
     fun onDataSaverSelected() {
         setCurrentQuality(QualityOptionsBottomSheet.QUALITY_DATA_SAVER)
-        pendingResolutionHeight = null
+        preferredResolutionHeight = null
         
         // Get the lowest available resolution
         val lowestResolution = availableResolutions.lastOrNull()?.dropLast(1)?.toIntOrNull()
@@ -110,7 +111,7 @@ class SettingsPanel(private val view: TPStreamsPlayerView) {
 
     fun setPreferredResolutionHeight(height: Int) {
         setCurrentQuality("${height}p")
-        pendingResolutionHeight = height
+        preferredResolutionHeight = height
         view.getPlayer()?.setUserResolutionPreference(height)
     }
 
@@ -119,13 +120,9 @@ class SettingsPanel(private val view: TPStreamsPlayerView) {
         setPreferredResolutionHeight(height)
     }
 
-    fun applyPendingResolutionPreference() {
-        pendingResolutionHeight?.let { height ->
-            val player = view.getPlayer()
-            if (player != null) {
-                player.setUserResolutionPreference(height)
-                pendingResolutionHeight = null
-            }
+    fun applyResolutionPreference() {
+        preferredResolutionHeight?.let { height ->
+            view.getPlayer()?.setUserResolutionPreference(height)
         }
     }
     

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/SettingsPanel.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/SettingsPanel.kt
@@ -63,12 +63,13 @@ class SettingsPanel(private val view: TPStreamsPlayerView) {
 
     fun onAutoQualitySelected() {
         setCurrentQuality(QualityOptionsBottomSheet.QUALITY_AUTO)
-    
+        pendingResolutionHeight = null
         view.getPlayer()?.setUserResolutionPreference(Int.MAX_VALUE)
     }
     
     fun onHigherQualitySelected() {
         setCurrentQuality(QualityOptionsBottomSheet.QUALITY_HIGHER)
+        pendingResolutionHeight = null
         
         // Get the highest available resolution
         val highestResolution = availableResolutions.firstOrNull()?.dropLast(1)?.toIntOrNull()
@@ -81,6 +82,7 @@ class SettingsPanel(private val view: TPStreamsPlayerView) {
     
     fun onDataSaverSelected() {
         setCurrentQuality(QualityOptionsBottomSheet.QUALITY_DATA_SAVER)
+        pendingResolutionHeight = null
         
         // Get the lowest available resolution
         val lowestResolution = availableResolutions.lastOrNull()?.dropLast(1)?.toIntOrNull()
@@ -107,7 +109,6 @@ class SettingsPanel(private val view: TPStreamsPlayerView) {
     }
 
     fun setPreferredResolutionHeight(height: Int) {
-        require(height > 0) { "Resolution height must be positive: $height" }
         setCurrentQuality("${height}p")
         pendingResolutionHeight = height
         view.getPlayer()?.setUserResolutionPreference(height)

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
@@ -372,7 +372,7 @@ class TPStreamsPlayerView @JvmOverloads constructor(
         super.setPlayer(player)
 
         // Apply any resolution preference that was set before the player was attached
-        settingsPanel.applyPendingResolutionPreference()
+        settingsPanel.applyResolutionPreference()
         
         if (player is TPStreamsPlayer) {
             val message = "[${player.playbackSessionId}] Surface ATTACH"

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
@@ -370,6 +370,9 @@ class TPStreamsPlayerView @JvmOverloads constructor(
         previousPlayer?.removeListener(playbackStateListener)
         
         super.setPlayer(player)
+
+        // Apply any resolution preference that was set before the player was attached
+        settingsPanel.applyPendingResolutionPreference()
         
         if (player is TPStreamsPlayer) {
             val message = "[${player.playbackSessionId}] Surface ATTACH"
@@ -522,7 +525,8 @@ class TPStreamsPlayerView @JvmOverloads constructor(
      * This is a user preference — the actual resolution may be capped by [TPStreamsPlayer.setMaxResolution].
      */
     fun setVideoResolution(height: Int) {
-        settingsPanel.onResolutionSelected("${height}p")
+        require(height > 0) { "Resolution height must be positive: $height" }
+        settingsPanel.setPreferredResolutionHeight(height)
     }
 
     // Implementation of PlaybackSpeedBottomSheet.PlaybackSpeedListener

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
@@ -517,6 +517,14 @@ class TPStreamsPlayerView @JvmOverloads constructor(
     // Implementation of AdvancedResolutionBottomSheet.ResolutionSelectionListener
     override fun onResolutionSelected(resolution: String) = settingsPanel.onResolutionSelected(resolution)
 
+    /**
+     * Sets the desired video resolution for playback and updates the settings UI.
+     * This is a user preference — the actual resolution may be capped by [TPStreamsPlayer.setMaxResolution].
+     */
+    fun setVideoResolution(height: Int) {
+        settingsPanel.onResolutionSelected("${height}p")
+    }
+
     // Implementation of PlaybackSpeedBottomSheet.PlaybackSpeedListener
     override fun onSpeedSelected(speed: Float) = settingsPanel.onSpeedSelected(speed)
 


### PR DESCRIPTION
- Add a public API to let apps set a preferred video resolution during online playback.
- The selected resolution is applied as a user preference while respecting the configured maximum resolution.
- Keep the player settings UI in sync by updating the selected quality and displayed label.