### PR TITLE
feat: Include SDK version in Sentry events

### DIFF
--- a/tpstreams-android-player/build.gradle.kts
+++ b/tpstreams-android-player/build.gradle.kts
@@ -3,6 +3,9 @@ plugins {
     alias(libs.plugins.kotlin.android)
 }
 
+group = "com.github.testpress"
+version = "1.2.0"
+
 android {
     namespace = "com.tpstreams.player"
     compileSdk = 35
@@ -57,8 +60,6 @@ dependencies {
 
 }
 apply(from = rootProject.file("gradle/gradle-mvn-build-packages.gradle"))
-group = "com.github.testpress"
-version = "1.2.0"
 
 afterEvaluate {
     tasks.findByName("publishReleasePublicationToMavenLocal")?.let { publishTask ->

--- a/tpstreams-android-player/build.gradle.kts
+++ b/tpstreams-android-player/build.gradle.kts
@@ -12,6 +12,12 @@ android {
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
+
+        buildConfigField("String", "SDK_VERSION", "\"${version}\"")
+    }
+
+    buildFeatures {
+        buildConfig = true
     }
 
     buildTypes {

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -58,8 +58,6 @@ import io.sentry.Breadcrumb
 import io.sentry.Sentry
 import io.sentry.SentryLevel
 
-import com.tpstreams.player.BuildConfig
-
 
 
 

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -58,6 +58,8 @@ import io.sentry.Breadcrumb
 import io.sentry.Sentry
 import io.sentry.SentryLevel
 
+import com.tpstreams.player.BuildConfig
+
 
 
 
@@ -375,7 +377,9 @@ private constructor(
                             networkDiagnosticsManager.handleError(error, cdnHostname = cdnHostname)
                         }
                     } else {
-                        Sentry.captureMessage("Non-network error from asset fetch: $error", SentryLevel.WARNING)
+                        Sentry.captureMessage("Non-network error from asset fetch: $error", SentryLevel.WARNING) { scope ->
+                            scope.setTag("sdkVersion", BuildConfig.SDK_VERSION)
+                        }
                         Sentry.addBreadcrumb(Breadcrumb().apply {
                             setMessage("Non-network error from asset fetch")
                             setData("error_type", error.name)

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/NetworkDiagnosticsManager.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/NetworkDiagnosticsManager.kt
@@ -3,6 +3,7 @@ package com.tpstreams.player.util
 import android.util.Log
 import androidx.media3.common.Player
 import androidx.media3.common.PlaybackException
+import com.tpstreams.player.BuildConfig
 import com.tpstreams.player.constants.NetworkDiagnostics
 import com.tpstreams.player.constants.PlaybackError
 import com.tpstreams.player.util.network.NetworkRecoveryHandler
@@ -205,6 +206,7 @@ internal class NetworkDiagnosticsManager(
             SentryLogger.logPlaybackException(exoError, assetId, playerId)
         } else {
             Sentry.captureMessage("Network error: $rootCause", SentryLevel.WARNING) { scope ->
+                scope.setTag("sdkVersion", BuildConfig.SDK_VERSION)
                 scope.setTag("playerId", playerId)
                 scope.setTag("assetId", assetId)
                 scope.setTag("rootCause", rootCause)

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/SentryLogger.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/SentryLogger.kt
@@ -1,6 +1,7 @@
 package com.tpstreams.player.util
 
 import androidx.media3.common.PlaybackException
+import com.tpstreams.player.BuildConfig
 import io.sentry.Sentry
 
 internal object SentryLogger {
@@ -24,6 +25,7 @@ internal object SentryLogger {
                 scope.setTag(key, value)
             }
             scope.setContexts("Clock Drift", ClockDriftDiagnostics.buildSentryClockContext(nowEpochMs))
+            scope.setTag("sdkVersion", BuildConfig.SDK_VERSION)
             scope.setTag("playerId", playerId)
             assetId?.let { scope.setTag("assetId", it) }
             drmLicenseUrl?.takeIf { it.isNotEmpty() }?.let { scope.setTag("drmLicenseUrl", it) }
@@ -57,6 +59,7 @@ internal object SentryLogger {
                 scope.setTag(key, value)
             }
             scope.setContexts("Clock Drift", ClockDriftDiagnostics.buildSentryClockContext(nowEpochMs))
+            scope.setTag("sdkVersion", BuildConfig.SDK_VERSION)
             scope.setTag("playerId", playerId)
             assetId?.let { scope.setTag("assetId", it) }
             responseCode?.let { scope.setTag("responseCode", it.toString()) }


### PR DESCRIPTION
- Sentry events did not include the SDK version, making it difficult to identify which SDK release was used when investigating issues.
- This required asking clients for their SDK version during almost every debugging session, slowing down issue resolution.
- This is fixed by including the SDK version as a tag in Sentry events, making it immediately available for troubleshooting and filtering.