### PR TITLE
feat: Enrich Sentry events with device, network, and player context

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -215,6 +215,19 @@ private constructor(
                 )
             }
 
+            override fun onAudioDecoderReleased(
+                eventTime: AnalyticsListener.EventTime,
+                decoderName: String
+            ) {
+                CodecManager.onDecoderReleased()
+                decoderState = decoderState.copy(
+                    audioDecoderName = null,
+                    audioDecoderIsHardware = null,
+                    audioMimeType = null
+                )
+                debugLog("Audio decoder RELEASED - Codec: $decoderName")
+            }
+
             override fun onVideoDecoderReleased(
                 eventTime: AnalyticsListener.EventTime,
                 decoderName: String
@@ -226,7 +239,7 @@ private constructor(
                     videoDecoderIsHardware = null,
                     videoMimeType = null
                 )
-                debugLog("Decoder RELEASED - Codec: $decoderName")
+                debugLog("Video decoder RELEASED - Codec: $decoderName")
             }
 
             override fun onVideoInputFormatChanged(

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -54,6 +54,8 @@ import androidx.media3.exoplayer.DecoderReuseEvaluation
 import com.tpstreams.player.util.PlaybackHistoryManager
 import com.tpstreams.player.util.CodecManager
 import com.tpstreams.player.util.ServerDateHeaderInterceptor
+import com.tpstreams.player.util.DecoderInfoProvider
+import com.tpstreams.player.data.PlayerDecoderState
 import io.sentry.Breadcrumb
 import io.sentry.Sentry
 import io.sentry.SentryLevel
@@ -120,10 +122,16 @@ private constructor(
     @Volatile
     private var cdnHostname: String? = null
 
+    // Per-player decoder state (not global — avoids cross-player corruption)
+    @Volatile
+    private var decoderState = PlayerDecoderState()
+    internal fun getDecoderState(): PlayerDecoderState = decoderState
+
     private val networkDiagnosticsManager = NetworkDiagnosticsManager(
         playerScope = playerScope,
         assetId = assetId,
         exoPlayer = exoPlayer,
+        context = context,
         networkRecoveryHandler = networkRecoveryHandler,
         listener = { error, message, diagnostics ->
             _listener?.onNetworkError(error, message, diagnostics)
@@ -186,7 +194,25 @@ private constructor(
                 initializationDurationMs: Long
             ) {
                 CodecManager.onDecoderInitialized()
+                val isHardware = DecoderInfoProvider.isDecoderHardware(decoderName)
+                decoderState = decoderState.copy(
+                    videoDecoderName = decoderName,
+                    videoDecoderIsHardware = isHardware
+                )
                 CodecManager.logCodecStatus(decoderName, "video/avc")
+            }
+
+            override fun onAudioDecoderInitialized(
+                eventTime: AnalyticsListener.EventTime,
+                decoderName: String,
+                initializedTimestampMs: Long,
+                initializationDurationMs: Long
+            ) {
+                val isHardware = DecoderInfoProvider.isDecoderHardware(decoderName)
+                decoderState = decoderState.copy(
+                    audioDecoderName = decoderName,
+                    audioDecoderIsHardware = isHardware
+                )
             }
 
             override fun onVideoDecoderReleased(
@@ -194,6 +220,12 @@ private constructor(
                 decoderName: String
             ) {
                 CodecManager.onDecoderReleased()
+                // Clear only video fields — audio decoder may still be active
+                decoderState = decoderState.copy(
+                    videoDecoderName = null,
+                    videoDecoderIsHardware = null,
+                    videoMimeType = null
+                )
                 debugLog("Decoder RELEASED - Codec: $decoderName")
             }
 
@@ -203,6 +235,7 @@ private constructor(
                 decoderReuseEvaluation: DecoderReuseEvaluation?
             ) {
                 debugLog("Decoder Format - ${format.sampleMimeType}, Res: ${format.width}x${format.height}, Bitrate: ${format.bitrate}")
+                decoderState = decoderState.copy(videoMimeType = format.sampleMimeType)
                 if (decoderReuseEvaluation != null) {
                     val resultLabel = when (decoderReuseEvaluation.result) {
                         DecoderReuseEvaluation.REUSE_RESULT_NO -> "NO"
@@ -228,6 +261,14 @@ private constructor(
 
             override fun onRenderedFirstFrame(eventTime: AnalyticsListener.EventTime, output: Any, renderTimeMs: Long) {
                 debugLog("First Frame Rendered")
+            }
+
+            override fun onAudioInputFormatChanged(
+                eventTime: AnalyticsListener.EventTime,
+                format: Format,
+                decoderReuseEvaluation: DecoderReuseEvaluation?
+            ) {
+                decoderState = decoderState.copy(audioMimeType = format.sampleMimeType)
             }
 
             override fun onSurfaceSizeChanged(eventTime: AnalyticsListener.EventTime, width: Int, height: Int) {
@@ -298,7 +339,7 @@ private constructor(
                 }
 
                 if (isNetworkError(error)) {
-                    networkDiagnosticsManager.handleError(error.toError(), error, cdnHostname)
+                    networkDiagnosticsManager.handleError(error.toError(), error, cdnHostname, decoderState)
                     return
                 }
                 
@@ -306,7 +347,7 @@ private constructor(
                 // Network errors route through handleError → manager → _listener?.onNetworkError().
                 debugLog("Player ERROR - ${error.errorCodeName}")
                 val errorPlayerId = SentryLogger.generatePlayerIdString()
-                SentryLogger.logPlaybackException(error, assetId, errorPlayerId, drmLicenseUrl)
+                SentryLogger.logPlaybackException(error, assetId, errorPlayerId, drmLicenseUrl = drmLicenseUrl, context = context, player = exoPlayer, decoderState = decoderState)
                 
                 val errorType = error.toError()
                 val errorMessage = error.getErrorMessage(errorPlayerId)
@@ -372,12 +413,17 @@ private constructor(
                     if (error == PlaybackError.NETWORK_CONNECTION_FAILED || 
                         error == PlaybackError.NETWORK_CONNECTION_TIMEOUT) {
                         playerScope.launch {
-                            networkDiagnosticsManager.handleError(error, cdnHostname = cdnHostname)
+                            networkDiagnosticsManager.handleError(error, cdnHostname = cdnHostname, decoderState = decoderState)
                         }
                     } else {
-                        Sentry.captureMessage("Non-network error from asset fetch: $error", SentryLevel.WARNING) { scope ->
-                            scope.setTag("sdkVersion", BuildConfig.SDK_VERSION)
-                        }
+                        SentryLogger.logMessageWithEnrichment(
+                            message = "Non-network error from asset fetch: $error",
+                            level = SentryLevel.WARNING,
+                            context = context,
+                            player = exoPlayer,
+                            decoderState = decoderState,
+                            tags = mapOf("assetId" to assetId, "errorType" to error.name)
+                        )
                         Sentry.addBreadcrumb(Breadcrumb().apply {
                             setMessage("Non-network error from asset fetch")
                             setData("error_type", error.name)
@@ -390,7 +436,7 @@ private constructor(
                         }
                     }
                 }
-            })
+            }, context = context)
         }
     }
 
@@ -587,6 +633,8 @@ private constructor(
         networkDiagnosticsManager.onRelease()
         exoPlayer.release()
         networkRecoveryHandler.stopMonitoring()
+        // Clear decoder state — audio decoder info would otherwise persist forever
+        decoderState = PlayerDecoderState()
     }
 
     @OptIn(UnstableApi::class)

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/data/AssetRepository.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/data/AssetRepository.kt
@@ -1,5 +1,6 @@
 package com.tpstreams.player.data
 
+import android.content.Context
 import com.tpstreams.player.TPStreamsSDK
 import com.tpstreams.player.constants.PlaybackError
 import com.tpstreams.player.constants.getErrorMessage
@@ -31,7 +32,8 @@ object AssetRepository {
         orgId: String,
         assetId: String,
         accessToken: String,
-        callback: AssetCallback
+        callback: AssetCallback,
+        context: Context? = null
     ) {
         TPStreamsSDK.requireOrgId()
         val apiService = TPStreamsSDK.apiService
@@ -46,7 +48,7 @@ object AssetRepository {
                 val response = client.newCall(request).execute()
 
                 if (!response.isSuccessful) {
-                    handleApiError(assetId, response.code, assetApiUrl, callback)
+                    handleApiError(assetId, response.code, assetApiUrl, callback, context)
                     return@launch
                 }
 
@@ -65,7 +67,7 @@ object AssetRepository {
                 }
             } catch (e: Exception) {
                 val url = runCatching { apiService.assetInfoUrl(orgId, assetId, accessToken) }.getOrNull() ?: ""
-                handleException(assetId, e, url, callback)
+                handleException(assetId, e, url, callback, context)
             }
         }
     }
@@ -73,14 +75,15 @@ object AssetRepository {
     fun fetchAssetInfo(
         assetId: String,
         accessToken: String,
-        callback: AssetCallback
+        callback: AssetCallback,
+        context: Context? = null
     ) {
-        fetchAssetInfo(TPStreamsSDK.requireOrgId(), assetId, accessToken, callback)
+        fetchAssetInfo(TPStreamsSDK.requireOrgId(), assetId, accessToken, callback, context)
     }
 
-    private fun handleApiError(assetId: String, code: Int, url: String, callback: AssetCallback) {
+    private fun handleApiError(assetId: String, code: Int, url: String, callback: AssetCallback, context: Context? = null) {
         val errorPlayerId = SentryLogger.generatePlayerIdString()
-        SentryLogger.logAPIException(Exception("API request failed with code: $code"), assetId, code, errorPlayerId, url)
+        SentryLogger.logAPIException(Exception("API request failed with code: $code"), assetId, code, errorPlayerId, url, context = context)
 
         val errorType = when (code) {
             404 -> PlaybackError.INVALID_ASSETS_ID
@@ -94,9 +97,9 @@ object AssetRepository {
         }
     }
 
-    private fun handleException(assetId: String, e: Exception, url: String, callback: AssetCallback) {
+    private fun handleException(assetId: String, e: Exception, url: String, callback: AssetCallback, context: Context? = null) {
         val errorPlayerId = SentryLogger.generatePlayerIdString()
-        SentryLogger.logAPIException(e, assetId, null, errorPlayerId, url)
+        SentryLogger.logAPIException(e, assetId, null, errorPlayerId, url, context = context)
 
         val errorType = e.toPlaybackError()
         val errorMessage = e.getErrorMessage(errorPlayerId, null)

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/data/SystemInfo.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/data/SystemInfo.kt
@@ -1,0 +1,41 @@
+package com.tpstreams.player.data
+
+/**
+ * Runtime storage and memory stats. Values are in MB.
+ */
+data class StorageMemoryInfo(
+    val availableRamMb: Long? = null,
+    val totalRamMb: Long? = null,
+    val lowMemory: Boolean? = null,
+    val availableStorageMb: Long? = null,
+    val totalStorageMb: Long? = null
+)
+
+/**
+ * Network connectivity details, collected permission-free where noted.
+ */
+data class NetworkInfo(
+    val networkType: String? = null,       // WIFI, CELLULAR, ETHERNET, VPN, UNKNOWN
+    val vpnActive: Boolean? = null,
+    val isRoaming: Boolean? = null,
+    val networkValidated: Boolean? = null,
+    val activeNetworkMetered: Boolean? = null,
+    val operatorName: String? = null       // Requires READ_PHONE_STATE
+)
+
+/**
+ * Current decoder state for a single player instance.
+ * Stored per-player in [TPStreamsPlayer] and passed to [DecoderInfoProvider]
+ * for Sentry enrichment — avoids the global-state race where one player's
+ * decoder info overwrites another's.
+ */
+internal data class PlayerDecoderState(
+    val videoDecoderName: String? = null,
+    val audioDecoderName: String? = null,
+    val videoDecoderIsHardware: Boolean? = null,
+    val audioDecoderIsHardware: Boolean? = null,
+    val videoMimeType: String? = null,
+    val audioMimeType: String? = null
+)
+
+

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/CodecManager.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/CodecManager.kt
@@ -6,6 +6,14 @@ import androidx.media3.common.util.Log
 import androidx.media3.common.util.UnstableApi
 import java.util.concurrent.atomic.AtomicInteger
 
+/**
+ * Process-wide codec tracking.
+ *
+ * Only [activeDecoderCount] and the helper methods [getMaxSupportedInstances]
+ * / [logCodecStatus] are process-level concerns. Decoder names, hardware
+ * flags, and MIME types are now stored **per player instance** inside
+ * [com.tpstreams.player.TPStreamsPlayer] — see [PlayerDecoderState].
+ */
 @OptIn(UnstableApi::class)
 object CodecManager {
     private const val TAG = "CodecManager"
@@ -40,7 +48,7 @@ object CodecManager {
         if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.M) {
             return -1
         }
-        
+
         return try {
             val codecList = MediaCodecList(MediaCodecList.ALL_CODECS)
             val info = codecList.codecInfos.find { it.name == codecName }
@@ -50,7 +58,7 @@ object CodecManager {
             -1
         }
     }
-    
+
     /**
      * Logs the current codec status.
      */
@@ -58,9 +66,9 @@ object CodecManager {
         val max = getMaxSupportedInstances(codecName, mimeType)
         val active = getActiveDecoderCount()
         val capacityStr = if (max > 0) max.toString() else "Unknown"
-        
+
         Log.d(TAG, "Codec Capacity Status - Codec: $codecName | Total Hardware Limit: $capacityStr | TPStreams Active: $active")
-        
+
         // Also add to play history for Sentry
         PlaybackHistoryManager.recordLog("CODEC_STATUS: $codecName, Limit: $capacityStr, Active: $active")
     }

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/DecoderInfoProvider.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/DecoderInfoProvider.kt
@@ -1,0 +1,112 @@
+package com.tpstreams.player.util
+
+import android.media.MediaCodecInfo
+import android.media.MediaCodecList
+import android.media.MediaDrm
+import android.os.Build
+import com.tpstreams.player.data.PlayerDecoderState
+import java.util.UUID
+
+/**
+ * Provider of decoder and DRM security-level information.
+ *
+ * Widevine security level is collected once (lazy) and cached.
+ * Decoder names, hardware flags, and MIME types are accepted as
+ * [PlayerDecoderState] — typically sourced from the current
+ * [com.tpstreams.player.TPStreamsPlayer] instance.
+ *
+ * Tags: widevine_security_level, active_decoder_count, video_decoder_name
+ * Context: all DecoderInfo fields
+ */
+internal object DecoderInfoProvider {
+
+    private const val WIDEVINE_UUID_STRING = "edef8ba9-79d6-4ace-a3c8-27dcd51d21ed"
+    private val WIDEVINE_UUID = UUID.fromString(WIDEVINE_UUID_STRING)
+
+    /** Cached Widevine security level. Collected once via MediaDrm. */
+    private val widevineLevel: String? by lazy { collectWidevineLevel() }
+
+    /** Returns tags for Sentry events using the given [decoderState]. */
+    fun buildTags(decoderState: PlayerDecoderState?): Map<String, String> {
+        return buildMap {
+            widevineLevel?.let { put("widevine_security_level", it) }
+            val activeCount = CodecManager.getActiveDecoderCount()
+            put("active_decoder_count", activeCount.toString())
+            decoderState?.videoDecoderName?.let { put("video_decoder_name", it) }
+            decoderState?.videoMimeType?.let { put("video_mime_type", it) }
+            decoderState?.audioMimeType?.let { put("audio_mime_type", it) }
+        }
+    }
+
+    /** Returns the full decoder context for Sentry using the given [decoderState]. */
+    fun buildContext(decoderState: PlayerDecoderState?): Map<String, Any> {
+        return buildMap {
+            decoderState?.videoDecoderName?.let { put("video_decoder_name", it) }
+            decoderState?.audioDecoderName?.let { put("audio_decoder_name", it) }
+            decoderState?.videoDecoderIsHardware?.let { put("video_decoder_is_hardware", it) }
+            decoderState?.audioDecoderIsHardware?.let { put("audio_decoder_is_hardware", it) }
+            decoderState?.videoMimeType?.let { put("video_mime_type", it) }
+            decoderState?.audioMimeType?.let { put("audio_mime_type", it) }
+            val activeCount = CodecManager.getActiveDecoderCount()
+            put("active_decoder_count", activeCount)
+            widevineLevel?.let { put("widevine_security_level", it) }
+        }
+    }
+
+/**
+ * Determines whether the given [decoderName] is hardware-accelerated.
+ *
+ * API 29+: uses [MediaCodecInfo.isHardwareAccelerated] (reliable).
+ * API 21-28: falls back to heuristic on decoder name patterns.
+ *
+ * **Heuristic caveats (API 21-28):**
+ * - "omx.google." is always software (Android's reference implementation)
+ * - ".sw." pattern indicates software decoder on some SoC implementations
+ * - "avc.decoder" is typically software (e.g., on Qualcomm/MTK low-tier)
+ * - **Not exhaustive** — some hardware decoders may be misclassified and
+ *   some software decoders may not match these patterns. Consider this
+ *   a best-effort signal, not authoritative.
+ */
+    fun isDecoderHardware(decoderName: String): Boolean {
+        return try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                // API 29+ has the reliable isHardwareAccelerated API
+                findCodecInfo(decoderName)?.isHardwareAccelerated ?: heuristicIsHardware(decoderName)
+            } else {
+                heuristicIsHardware(decoderName)
+            }
+        } catch (_: Exception) {
+            heuristicIsHardware(decoderName)
+        }
+    }
+
+    private fun findCodecInfo(decoderName: String): MediaCodecInfo? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) return null
+        val codecList = MediaCodecList(MediaCodecList.ALL_CODECS)
+        for (info in codecList.codecInfos) {
+            if (info.name == decoderName) return info
+        }
+        return null
+    }
+
+    private fun heuristicIsHardware(decoderName: String): Boolean {
+        val lower = decoderName.lowercase()
+        // Software decoders typically have these patterns
+        if (lower.contains("omx.google.") || lower.contains(".sw.") || lower.contains("avc.decoder")) return false
+        return true
+    }
+
+    private fun collectWidevineLevel(): String? {
+        return try {
+            val mediaDrm = MediaDrm(WIDEVINE_UUID)
+            try {
+                mediaDrm.getPropertyString("securityLevel")
+            } finally {
+                // close() requires API 28+; release() works on all versions
+                if (Build.VERSION.SDK_INT >= 28) mediaDrm.close() else mediaDrm.release()
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+}

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/DecoderInfoProvider.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/DecoderInfoProvider.kt
@@ -6,6 +6,7 @@ import android.media.MediaDrm
 import android.os.Build
 import com.tpstreams.player.data.PlayerDecoderState
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Provider of decoder and DRM security-level information.
@@ -25,6 +26,9 @@ internal object DecoderInfoProvider {
 
     /** Cached Widevine security level. Collected once via MediaDrm. */
     private val widevineLevel: String? by lazy { collectWidevineLevel() }
+
+    /** Cache of isDecoderHardware results to avoid redundant MediaCodecList enumeration. */
+    private val decoderHardwareCache = ConcurrentHashMap<String, Boolean>()
 
     /** Returns tags for Sentry events using the given [decoderState]. */
     fun buildTags(decoderState: PlayerDecoderState?): Map<String, String> {
@@ -53,30 +57,33 @@ internal object DecoderInfoProvider {
         }
     }
 
-/**
- * Determines whether the given [decoderName] is hardware-accelerated.
- *
- * API 29+: uses [MediaCodecInfo.isHardwareAccelerated] (reliable).
- * API 21-28: falls back to heuristic on decoder name patterns.
- *
- * **Heuristic caveats (API 21-28):**
- * - "omx.google." is always software (Android's reference implementation)
- * - ".sw." pattern indicates software decoder on some SoC implementations
- * - "avc.decoder" is typically software (e.g., on Qualcomm/MTK low-tier)
- * - **Not exhaustive** — some hardware decoders may be misclassified and
- *   some software decoders may not match these patterns. Consider this
- *   a best-effort signal, not authoritative.
- */
+    /**
+     * Determines whether the given [decoderName] is hardware-accelerated.
+     *
+     * API 29+: uses [MediaCodecInfo.isHardwareAccelerated] (reliable).
+     * API 21-28: falls back to heuristic on decoder name patterns.
+     *
+     * Results are cached per decoder name to avoid repeated MediaCodecList enumeration.
+     *
+     * **Heuristic caveats (API 21-28):**
+     * - "omx.google." is always software (Android's reference implementation)
+     * - ".sw." pattern indicates software decoder on some SoC implementations
+     * - "avc.decoder" is typically software (e.g., on Qualcomm/MTK low-tier)
+     * - **Not exhaustive** — some hardware decoders may be misclassified and
+     *   some software decoders may not match these patterns. Consider this
+     *   a best-effort signal, not authoritative.
+     */
     fun isDecoderHardware(decoderName: String): Boolean {
-        return try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                // API 29+ has the reliable isHardwareAccelerated API
-                findCodecInfo(decoderName)?.isHardwareAccelerated ?: heuristicIsHardware(decoderName)
-            } else {
+        return decoderHardwareCache.getOrPut(decoderName) {
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    findCodecInfo(decoderName)?.isHardwareAccelerated ?: heuristicIsHardware(decoderName)
+                } else {
+                    heuristicIsHardware(decoderName)
+                }
+            } catch (_: Exception) {
                 heuristicIsHardware(decoderName)
             }
-        } catch (_: Exception) {
-            heuristicIsHardware(decoderName)
         }
     }
 
@@ -91,18 +98,17 @@ internal object DecoderInfoProvider {
 
     private fun heuristicIsHardware(decoderName: String): Boolean {
         val lower = decoderName.lowercase()
-        // Software decoders typically have these patterns
         if (lower.contains("omx.google.") || lower.contains(".sw.") || lower.contains("avc.decoder")) return false
         return true
     }
 
     private fun collectWidevineLevel(): String? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) return null
         return try {
             val mediaDrm = MediaDrm(WIDEVINE_UUID)
             try {
                 mediaDrm.getPropertyString("securityLevel")
             } finally {
-                // close() requires API 28+; release() works on all versions
                 if (Build.VERSION.SDK_INT >= 28) mediaDrm.close() else mediaDrm.release()
             }
         } catch (_: Exception) {

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/DeviceInfoProvider.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/DeviceInfoProvider.kt
@@ -1,0 +1,115 @@
+package com.tpstreams.player.util
+
+import android.content.Context
+import android.content.res.Configuration
+import android.os.Build
+import android.util.DisplayMetrics
+import android.view.WindowManager
+
+/**
+ * Permission-free provider of device hardware and OS information.
+ *
+ * Context-free fields (manufacturer, model, brand, version, SDK, emulator) are
+ * collected once and cached permanently. Context-dependent fields (screen
+ * resolution, locale) are collected fresh on every call via the supplied
+ * [context] parameter — no global state required.
+ *
+ * Tags (included in every Sentry event): manufacturer, device_model, device_brand,
+ * hardware, android_version, sdk_int, is_emulator, screen_resolution
+ * Context (full details on demand): all fields including device_locale
+ */
+internal object DeviceInfoProvider {
+
+    // ── Context-free fields: cached once ────────────────────────────────
+
+    private val manufacturer: String? by lazy { safeGet { Build.MANUFACTURER } }
+    private val deviceModel: String? by lazy { safeGet { Build.MODEL } }
+    private val deviceBrand: String? by lazy { safeGet { Build.BRAND } }
+    private val chipBrand: String? by lazy { safeGet { resolveChipBrand() } }
+    private val androidVersion: String? by lazy { safeGet { Build.VERSION.RELEASE } }
+    private val sdkInt: Int? by lazy { safeGet { Build.VERSION.SDK_INT } }
+    private val emulator: Boolean? by lazy { safeGet { isEmulator() } }
+
+    // ── Public API ──────────────────────────────────────────────────────
+
+    /** Returns tags for searchability in Sentry. Context needed for screen resolution. */
+    fun getTags(context: Context? = null): Map<String, String> {
+        return buildMap {
+            manufacturer?.let { put("manufacturer", it) }
+            deviceModel?.let { put("device_model", it) }
+            deviceBrand?.let { put("device_brand", it) }
+            chipBrand?.let { put("hardware", it) }
+            androidVersion?.let { put("android_version", it) }
+            sdkInt?.let { put("sdk_int", it.toString()) }
+            emulator?.let { put("is_emulator", it.toString()) }
+            if (context != null) {
+                safeGet { resolveScreenResolution(context) }?.let { put("screen_resolution", it) }
+            }
+        }
+    }
+
+    /** Returns the full device context for Sentry's contexts mechanism. */
+    fun getContext(context: Context? = null): Map<String, Any> {
+        return buildMap {
+            manufacturer?.let { put("manufacturer", it) }
+            deviceModel?.let { put("device_model", it) }
+            deviceBrand?.let { put("device_brand", it) }
+            chipBrand?.let { put("hardware", it) }
+            androidVersion?.let { put("android_version", it) }
+            sdkInt?.let { put("sdk_int", it) }
+            if (context != null) {
+                safeGet { resolveScreenResolution(context) }?.let { put("screen_resolution", it) }
+                safeGet { resolveDeviceLocale(context) }?.let { put("device_locale", it) }
+            }
+            emulator?.let { put("is_emulator", it) }
+        }
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────
+
+    private fun resolveScreenResolution(context: Context): String? {
+        val wm = context.getSystemService(Context.WINDOW_SERVICE) as? WindowManager ?: return null
+        val display = wm.defaultDisplay ?: return null
+        val metrics = DisplayMetrics().also { display.getRealMetrics(it) }
+        return "${metrics.widthPixels}x${metrics.heightPixels}@${metrics.densityDpi}dpi"
+    }
+
+    private fun resolveChipBrand(): String? {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            Build.SOC_MANUFACTURER?.takeIf { it.isNotBlank() }
+        } else {
+            Build.HARDWARE?.takeIf { it.isNotBlank() }
+        }
+    }
+
+    private fun isEmulator(): Boolean {
+        val fingerprint = Build.FINGERPRINT
+        val model = Build.MODEL
+        val hardware = Build.HARDWARE
+        return fingerprint.contains("google_sdk") ||
+                fingerprint.contains("generic") ||
+                model.contains("sdk") ||
+                model.contains("emulator") ||
+                hardware.contains("goldfish") ||
+                hardware.contains("ranchu")
+    }
+
+    private fun resolveDeviceLocale(context: Context): String? {
+        val config = context.resources.configuration
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            config.locales.get(0).toLanguageTag()
+        } else {
+            @Suppress("DEPRECATION")
+            config.locale.toLanguageTag()
+        }
+    }
+
+    private fun <T> safeGet(block: () -> T?): T? = try {
+        block()
+    } catch (e: Exception) {
+        android.util.Log.d(TAG, "Failed to collect device info field", e)
+        null
+    }
+
+    private const val TAG = "DeviceInfoProvider"
+}

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/DeviceInfoProvider.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/DeviceInfoProvider.kt
@@ -100,12 +100,7 @@ internal object DeviceInfoProvider {
             config.locales.get(0).toLanguageTag()
         } else {
             @Suppress("DEPRECATION")
-            val locale = config.locale
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                locale.toLanguageTag()
-            } else {
-                locale.toString()
-            }
+            config.locale.toLanguageTag()
         }
     }
 

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/DeviceInfoProvider.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/DeviceInfoProvider.kt
@@ -100,7 +100,12 @@ internal object DeviceInfoProvider {
             config.locales.get(0).toLanguageTag()
         } else {
             @Suppress("DEPRECATION")
-            config.locale.toLanguageTag()
+            val locale = config.locale
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                locale.toLanguageTag()
+            } else {
+                locale.toString()
+            }
         }
     }
 

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/NetworkDiagnosticsManager.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/NetworkDiagnosticsManager.kt
@@ -1,15 +1,15 @@
 package com.tpstreams.player.util
 
+import android.content.Context
 import android.util.Log
 import androidx.media3.common.Player
 import androidx.media3.common.PlaybackException
-import com.tpstreams.player.BuildConfig
 import com.tpstreams.player.constants.NetworkDiagnostics
 import com.tpstreams.player.constants.PlaybackError
+import com.tpstreams.player.data.PlayerDecoderState
 import com.tpstreams.player.util.network.NetworkRecoveryHandler
 import io.sentry.Breadcrumb
 import io.sentry.Sentry
-import io.sentry.SentryLevel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -20,12 +20,15 @@ internal class NetworkDiagnosticsManager(
     private val playerScope: CoroutineScope,
     private val assetId: String,
     private val exoPlayer: Player,
+    context: Context? = null,
     private val networkRecoveryHandler: NetworkRecoveryHandler,
     private val listener: (PlaybackError, String, NetworkDiagnostics) -> Unit,
     private val retryPlayback: () -> Unit,
     private val onDiagnosticsStarted: (() -> Unit)? = null,
     private val diagnosticHost: String = DIAGNOSTIC_HOST_DEFAULT
 ) {
+    // Application context to avoid Activity leaks
+    private val appContext: Context? = context?.applicationContext
     private val probeRunner = NetworkProbeRunner(diagnosticHost)
 
     private var networkErrorJob: Job? = null
@@ -84,7 +87,7 @@ internal class NetworkDiagnosticsManager(
         networkErrorJob?.cancel()
     }
 
-    fun handleError(errorType: PlaybackError, exoError: PlaybackException? = null, cdnHostname: String? = null) {
+    fun handleError(errorType: PlaybackError, exoError: PlaybackException? = null, cdnHostname: String? = null, decoderState: PlayerDecoderState? = null) {
         networkErrorJob?.cancel()
         val attempt = ++probeGeneration
         hasPendingError = true
@@ -123,7 +126,7 @@ internal class NetworkDiagnosticsManager(
             val playerId = SentryLogger.generatePlayerIdString()
 
             addSentryBreadcrumb(rootCause, displayAttempt, canAutoRetry, diagnostics, finalError, exoPlayer, playerId)
-            val sentryEventId = sendSentryEvent(exoError, rootCause, finalError, diagnostics, playerId, canAutoRetry)
+            val sentryEventId = sendSentryEvent(exoError, rootCause, finalError, diagnostics, playerId, canAutoRetry, exoPlayer, decoderState)
             Log.e(DEBUG_TAG, "Network error: $message (sentry: ${sentryEventId ?: "null"})", exoError)
 
             val isFinal = !canAutoRetry
@@ -199,31 +202,30 @@ internal class NetworkDiagnosticsManager(
 
     private fun sendSentryEvent(
         exoError: PlaybackException?, rootCause: String, finalError: PlaybackError,
-        diagnostics: NetworkDiagnostics, playerId: String, canAutoRetry: Boolean
+        diagnostics: NetworkDiagnostics, playerId: String, canAutoRetry: Boolean,
+        player: Player? = null, decoderState: PlayerDecoderState? = null
     ): String? {
         if (canAutoRetry) return null
         return if (exoError != null) {
-            SentryLogger.logPlaybackException(exoError, assetId, playerId)
+            SentryLogger.logPlaybackException(exoError, assetId, playerId, rootCause = rootCause, context = appContext, player = player, decoderState = decoderState)
         } else {
-            Sentry.captureMessage("Network error: $rootCause", SentryLevel.WARNING) { scope ->
-                scope.setTag("sdkVersion", BuildConfig.SDK_VERSION)
-                scope.setTag("playerId", playerId)
-                scope.setTag("assetId", assetId)
-                scope.setTag("rootCause", rootCause)
-                scope.setContexts("TPStreamsPlayer", mapOf<String, Any>(
-                    "Player ID" to playerId,
-                    "Asset ID" to assetId,
-                    "Root Cause" to rootCause,
-                    "Final Error" to finalError.name,
-                    "Diagnosis" to mapOf(
-                        "Internet" to diagnostics.internetReachable.toString(),
-                        "DNS" to diagnostics.dnsResolves.toString(),
-                        "Server" to diagnostics.serverReachable.toString(),
-                        "CDN" to (diagnostics.cdnReachable?.toString() ?: "skipped"),
-                        "Proxy" to diagnostics.proxyConfigured.toString()
-                    )
-                ))
-            }?.toString()
+            SentryLogger.logMessageWithEnrichment(
+                message = "Network error: $rootCause",
+                level = io.sentry.SentryLevel.WARNING,
+                context = appContext,
+                player = player,
+                tags = mapOf(
+                    "playerId" to playerId,
+                    "assetId" to assetId,
+                    "rootCause" to rootCause,
+                    "finalError" to finalError.name,
+                    "network_internet" to diagnostics.internetReachable.toString(),
+                    "network_dns" to diagnostics.dnsResolves.toString(),
+                    "network_server" to diagnostics.serverReachable.toString(),
+                    "network_cdn" to (diagnostics.cdnReachable?.toString() ?: "skipped"),
+                    "network_proxy" to diagnostics.proxyConfigured.toString()
+                )
+            )
         }
     }
 

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/NetworkInfoProvider.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/NetworkInfoProvider.kt
@@ -1,0 +1,110 @@
+package com.tpstreams.player.util
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.os.Build
+import android.telephony.TelephonyManager
+import androidx.core.content.ContextCompat
+import com.tpstreams.player.data.NetworkInfo
+
+/**
+ * Stateless provider of network connectivity information.
+ *
+ * All fields are permission-free except operatorName (requires READ_PHONE_STATE).
+ * Values are collected fresh on every call.
+ *
+ * Tags: network_type, vpn_active, network_validated, operator_name
+ * Context: all NetworkInfo fields
+ */
+internal object NetworkInfoProvider {
+
+    /** Returns tags for Sentry events. */
+    fun getTags(context: Context? = null): Map<String, String> {
+        if (context == null) return emptyMap()
+        val info = getNetworkInfo(context)
+        return buildMap {
+            info.networkType?.let { put("network_type", it) }
+            info.vpnActive?.let { put("vpn_active", it.toString()) }
+            info.networkValidated?.let { put("network_validated", it.toString()) }
+            info.operatorName?.let { put("operator_name", it) }
+        }
+    }
+
+    /** Returns the full network context. */
+    fun getContext(context: Context? = null): Map<String, Any> {
+        if (context == null) return emptyMap()
+        val info = getNetworkInfo(context)
+        return buildMap {
+            info.networkType?.let { put("network_type", it) }
+            info.vpnActive?.let { put("vpn_active", it) }
+            info.isRoaming?.let { put("is_roaming", it) }
+            info.networkValidated?.let { put("network_validated", it) }
+            info.activeNetworkMetered?.let { put("active_network_metered", it) }
+            info.operatorName?.let { put("operator_name", it) }
+        }
+    }
+
+    private fun getNetworkInfo(context: Context): NetworkInfo {
+        return try {
+            val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+            if (connectivityManager == null) return NetworkInfo()
+
+            val activeNetwork = connectivityManager.activeNetwork
+            val capabilities = activeNetwork?.let { connectivityManager.getNetworkCapabilities(it) }
+
+            val networkType = capabilities?.let { classifyNetworkType(it) }
+            val vpnActive = capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_VPN) ?: false
+            val isRoamingRaw = capabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_ROAMING)
+            val isRoaming = when (isRoamingRaw) {
+                null -> null   // unknown
+                true -> false  // NOT_ROAMING present → not roaming
+                false -> true  // NOT_ROAMING absent → is roaming
+            }
+            val networkValidated = capabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+            val isMetered = connectivityManager.isActiveNetworkMetered
+            val operatorName = getOperatorName(context)
+
+            NetworkInfo(
+                networkType = networkType,
+                vpnActive = vpnActive,
+                isRoaming = isRoaming,
+                networkValidated = networkValidated,
+                activeNetworkMetered = isMetered,
+                operatorName = operatorName
+            )
+        } catch (_: Exception) {
+            NetworkInfo()
+        }
+    }
+
+    private fun classifyNetworkType(capabilities: NetworkCapabilities): String {
+        // VPN first — network_type answers "what kind of connection is this?"
+        // vpn_active separately confirms VPN overlay.
+        return when {
+            capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN) -> "VPN"
+            capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> "WIFI"
+            capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> "CELLULAR"
+            capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) -> "ETHERNET"
+            capabilities.hasTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH) -> "BLUETOOTH"
+            else -> "UNKNOWN"
+        }
+    }
+
+    private fun getOperatorName(context: Context): String? {
+        return try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                if (ContextCompat.checkSelfPermission(context, Manifest.permission.READ_PHONE_STATE)
+                    != PackageManager.PERMISSION_GRANTED) {
+                    return null
+                }
+            }
+            val tm = context.getSystemService(Context.TELEPHONY_SERVICE) as? TelephonyManager
+            tm?.networkOperatorName?.takeIf { it.isNotBlank() }
+        } catch (_: Exception) {
+            null
+        }
+    }
+}

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/NetworkInfoProvider.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/NetworkInfoProvider.kt
@@ -16,65 +16,61 @@ import com.tpstreams.player.data.NetworkInfo
  * All fields are permission-free except operatorName (requires READ_PHONE_STATE).
  * Values are collected fresh on every call.
  *
- * Tags: network_type, vpn_active, network_validated, operator_name
- * Context: all NetworkInfo fields
+ * Internal info methods should be preferred when both tags and context are needed —
+ * use [getNetworkInfo] once and build maps from the result.
  */
 internal object NetworkInfoProvider {
 
-    /** Returns tags for Sentry events. */
-    fun getTags(context: Context? = null): Map<String, String> {
-        if (context == null) return emptyMap()
-        val info = getNetworkInfo(context)
-        return buildMap {
-            info.networkType?.let { put("network_type", it) }
-            info.vpnActive?.let { put("vpn_active", it.toString()) }
-            info.networkValidated?.let { put("network_validated", it.toString()) }
-            info.operatorName?.let { put("operator_name", it) }
-        }
-    }
-
-    /** Returns the full network context. */
-    fun getContext(context: Context? = null): Map<String, Any> {
-        if (context == null) return emptyMap()
-        val info = getNetworkInfo(context)
-        return buildMap {
-            info.networkType?.let { put("network_type", it) }
-            info.vpnActive?.let { put("vpn_active", it) }
-            info.isRoaming?.let { put("is_roaming", it) }
-            info.networkValidated?.let { put("network_validated", it) }
-            info.activeNetworkMetered?.let { put("active_network_metered", it) }
-            info.operatorName?.let { put("operator_name", it) }
-        }
-    }
-
-    private fun getNetworkInfo(context: Context): NetworkInfo {
+    /**
+     * Returns the raw network info for the given [context].
+     * Use this to avoid redundant system queries when building both tags and context.
+     */
+    internal fun getNetworkInfo(context: Context): NetworkInfo {
         return try {
             val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
             if (connectivityManager == null) return NetworkInfo()
 
-            val activeNetwork = connectivityManager.activeNetwork
-            val capabilities = activeNetwork?.let { connectivityManager.getNetworkCapabilities(it) }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                // API 23+: modern NetworkCapabilities-based API
+                val activeNetwork = connectivityManager.activeNetwork
+                val capabilities = activeNetwork?.let { connectivityManager.getNetworkCapabilities(it) }
 
-            val networkType = capabilities?.let { classifyNetworkType(it) }
-            val vpnActive = capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_VPN) ?: false
-            val isRoamingRaw = capabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_ROAMING)
-            val isRoaming = when (isRoamingRaw) {
-                null -> null   // unknown
-                true -> false  // NOT_ROAMING present → not roaming
-                false -> true  // NOT_ROAMING absent → is roaming
+                val networkType = capabilities?.let { classifyNetworkType(it) }
+                val vpnActive = capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_VPN) ?: false
+                val isRoamingRaw = capabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_ROAMING)
+                val isRoaming = when (isRoamingRaw) {
+                    null -> null   // unknown
+                    true -> false  // NOT_ROAMING present → not roaming
+                    false -> true  // NOT_ROAMING absent → is roaming
+                }
+                val networkValidated = capabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+                val isMetered = connectivityManager.isActiveNetworkMetered
+                val operatorName = getOperatorName(context)
+
+                NetworkInfo(
+                    networkType = networkType,
+                    vpnActive = vpnActive,
+                    isRoaming = isRoaming,
+                    networkValidated = networkValidated,
+                    activeNetworkMetered = isMetered,
+                    operatorName = operatorName
+                )
+            } else {
+                // API 21-22: fallback using deprecated activeNetworkInfo
+                @Suppress("DEPRECATION")
+                val activeInfo = connectivityManager.activeNetworkInfo
+                val networkType = when (activeInfo?.type) {
+                    ConnectivityManager.TYPE_WIFI -> "WIFI"
+                    ConnectivityManager.TYPE_MOBILE -> "CELLULAR"
+                    ConnectivityManager.TYPE_ETHERNET -> "ETHERNET"
+                    else -> "UNKNOWN"
+                }
+                NetworkInfo(
+                    networkType = networkType,
+                    isRoaming = activeInfo?.isRoaming,
+                    operatorName = getOperatorName(context)
+                )
             }
-            val networkValidated = capabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
-            val isMetered = connectivityManager.isActiveNetworkMetered
-            val operatorName = getOperatorName(context)
-
-            NetworkInfo(
-                networkType = networkType,
-                vpnActive = vpnActive,
-                isRoaming = isRoaming,
-                networkValidated = networkValidated,
-                activeNetworkMetered = isMetered,
-                operatorName = operatorName
-            )
         } catch (_: Exception) {
             NetworkInfo()
         }

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/PlayerStateSnapshot.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/PlayerStateSnapshot.kt
@@ -1,0 +1,68 @@
+package com.tpstreams.player.util
+
+import androidx.media3.common.Player
+
+/**
+ * Snapshot of the ExoPlayer state at a point in time.
+ *
+ * All fields nullable — player may be null or in an intermediate state.
+ */
+data class PlayerStateSnapshot(
+    val playerState: String? = null,        // IDLE, BUFFERING, READY, ENDED
+    val playWhenReady: Boolean? = null,
+    val currentPositionMs: Long? = null,
+    val bufferedPositionMs: Long? = null,
+    val playbackSpeed: Float? = null,
+    val volume: Float? = null
+) {
+    companion object {
+        /**
+         * Captures a snapshot of the given [player].
+         * Returns a [PlayerStateSnapshot] with all fields populated if player is non-null.
+         */
+        fun capture(player: Player?): PlayerStateSnapshot {
+            if (player == null) return PlayerStateSnapshot()
+
+            return try {
+                val stateName = when (player.playbackState) {
+                    Player.STATE_IDLE -> "IDLE"
+                    Player.STATE_BUFFERING -> "BUFFERING"
+                    Player.STATE_READY -> "READY"
+                    Player.STATE_ENDED -> "ENDED"
+                    else -> "UNKNOWN"
+                }
+
+                PlayerStateSnapshot(
+                    playerState = stateName,
+                    playWhenReady = player.playWhenReady,
+                    currentPositionMs = if (player.currentPosition >= 0) player.currentPosition else null,
+                    bufferedPositionMs = if (player.bufferedPosition >= 0) player.bufferedPosition else null,
+                    playbackSpeed = player.playbackParameters.speed,
+                    volume = player.volume
+                )
+            } catch (_: Exception) {
+                PlayerStateSnapshot()
+            }
+        }
+    }
+
+    /** Returns tags for Sentry events. */
+    fun getTags(): Map<String, String> {
+        return buildMap {
+            playerState?.let { put("player_state", it) }
+            playWhenReady?.let { put("play_when_ready", it.toString()) }
+        }
+    }
+
+    /** Returns the full player context for Sentry. */
+    fun getContext(): Map<String, Any> {
+        return buildMap {
+            playerState?.let { put("player_state", it) }
+            playWhenReady?.let { put("play_when_ready", it) }
+            currentPositionMs?.let { put("current_position_ms", it) }
+            bufferedPositionMs?.let { put("buffered_position_ms", it) }
+            playbackSpeed?.let { put("playback_speed", it) }
+            volume?.let { put("volume", it) }
+        }
+    }
+}

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/SentryLogger.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/SentryLogger.kt
@@ -1,8 +1,13 @@
 package com.tpstreams.player.util
 
+import android.content.Context
 import androidx.media3.common.PlaybackException
+import androidx.media3.common.Player
 import com.tpstreams.player.BuildConfig
+import com.tpstreams.player.data.PlayerDecoderState
+import io.sentry.IScope
 import io.sentry.Sentry
+import io.sentry.SentryLevel
 
 internal object SentryLogger {
 
@@ -13,11 +18,68 @@ internal object SentryLogger {
             .joinToString("")
     }
 
+    /**
+     * Enriches the Sentry [scope] with device, network, storage, decoder, and player state.
+     *
+     * All providers are best-effort — if one throws, only that provider's data is lost.
+     * Context-dependent providers ([StorageMemoryProvider], [NetworkInfoProvider]) are
+     * skipped when [context] is null. Decoder state is sourced from [decoderState] which
+     * should be the calling player's [PlayerDecoderState].
+     */
+    fun enrichScope(
+        context: Context? = null,
+        player: Player? = null,
+        decoderState: PlayerDecoderState? = null,
+        errorCategory: String? = null,
+        scope: IScope
+    ) {
+        // Error category — high-level classification for triage
+        errorCategory?.let { scope.setTag("error_category", it) }
+
+        // SDK version — included on every event for searchability
+        scope.setTag("sdkVersion", BuildConfig.SDK_VERSION)
+
+        // Device info (cached fields always work, screen resolution needs context)
+        try {
+            DeviceInfoProvider.getTags(context).forEach { (key, value) -> scope.setTag(key, value) }
+            scope.setContexts("Device Info", DeviceInfoProvider.getContext(context))
+        } catch (_: Exception) { /* best-effort */ }
+
+        // Storage & memory (needs context)
+        if (context != null) try {
+            StorageMemoryProvider.getTags(context).forEach { (key, value) -> scope.setTag(key, value) }
+            scope.setContexts("Storage & Memory", StorageMemoryProvider.getContext(context))
+        } catch (_: Exception) { /* best-effort */ }
+
+        // Network info (needs context)
+        if (context != null) try {
+            NetworkInfoProvider.getTags(context).forEach { (key, value) -> scope.setTag(key, value) }
+            scope.setContexts("Network Info", NetworkInfoProvider.getContext(context))
+        } catch (_: Exception) { /* best-effort */ }
+
+        // Player state snapshot
+        try {
+            val snapshot = PlayerStateSnapshot.capture(player)
+            snapshot.getTags().forEach { (key, value) -> scope.setTag(key, value) }
+            scope.setContexts("Player State", snapshot.getContext())
+        } catch (_: Exception) { /* best-effort */ }
+
+        // Decoder info
+        try {
+            DecoderInfoProvider.buildTags(decoderState).forEach { (key, value) -> scope.setTag(key, value) }
+            scope.setContexts("Decoder Info", DecoderInfoProvider.buildContext(decoderState))
+        } catch (_: Exception) { /* best-effort */ }
+    }
+
     fun logPlaybackException(
         error: PlaybackException,
         assetId: String?,
         playerId: String,
-        drmLicenseUrl: String? = null
+        drmLicenseUrl: String? = null,
+        rootCause: String? = null,
+        context: Context? = null,
+        player: Player? = null,
+        decoderState: PlayerDecoderState? = null
     ): String? {
         return Sentry.captureException(error) { scope ->
             val nowEpochMs = System.currentTimeMillis()
@@ -25,10 +87,10 @@ internal object SentryLogger {
                 scope.setTag(key, value)
             }
             scope.setContexts("Clock Drift", ClockDriftDiagnostics.buildSentryClockContext(nowEpochMs))
-            scope.setTag("sdkVersion", BuildConfig.SDK_VERSION)
             scope.setTag("playerId", playerId)
             assetId?.let { scope.setTag("assetId", it) }
             drmLicenseUrl?.takeIf { it.isNotEmpty() }?.let { scope.setTag("drmLicenseUrl", it) }
+            rootCause?.let { scope.setTag("rootCause", it) }
             scope.setContexts(
                 "TPStreamsPlayer",
                 mapOf(
@@ -43,6 +105,13 @@ internal object SentryLogger {
                 "Playback History",
                 mapOf("Timeline" to PlaybackHistoryManager.getFullHistory())
             )
+            val category = when {
+                rootCause != null -> "NETWORK"
+                error.errorCodeName?.contains("DRM", ignoreCase = true) == true -> "DRM"
+                error.errorCodeName?.contains("DECODER", ignoreCase = true) == true -> "DECODER"
+                else -> "PLAYBACK"
+            }
+            enrichScope(context = context, player = player, decoderState = decoderState, errorCategory = category, scope = scope)
         }?.toString()
     }
 
@@ -51,7 +120,9 @@ internal object SentryLogger {
         assetId: String?,
         responseCode: Int?,
         playerId: String,
-        url: String? = null
+        url: String? = null,
+        context: Context? = null,
+        player: Player? = null
     ): String? {
         return Sentry.captureException(exception) { scope ->
             val nowEpochMs = System.currentTimeMillis()
@@ -59,7 +130,6 @@ internal object SentryLogger {
                 scope.setTag(key, value)
             }
             scope.setContexts("Clock Drift", ClockDriftDiagnostics.buildSentryClockContext(nowEpochMs))
-            scope.setTag("sdkVersion", BuildConfig.SDK_VERSION)
             scope.setTag("playerId", playerId)
             assetId?.let { scope.setTag("assetId", it) }
             responseCode?.let { scope.setTag("responseCode", it.toString()) }
@@ -73,7 +143,26 @@ internal object SentryLogger {
                     "Request URL" to (url?.takeIf { it.isNotEmpty() } ?: "N/A")
                 )
             )
+            enrichScope(context = context, player = player, errorCategory = "API", scope = scope)
+        }?.toString()
+    }
+
+    fun logMessageWithEnrichment(
+        message: String,
+        level: SentryLevel = SentryLevel.WARNING,
+        context: Context? = null,
+        player: Player? = null,
+        decoderState: PlayerDecoderState? = null,
+        tags: Map<String, String> = emptyMap()
+    ): String? {
+        return Sentry.captureMessage(message, level) { scope ->
+            tags.forEach { (key, value) -> scope.setTag(key, value) }
+            scope.setContexts(
+                "Playback History",
+                mapOf("Timeline" to PlaybackHistoryManager.getFullHistory())
+            )
+            val category = if (tags.containsKey("rootCause")) "NETWORK" else "UNKNOWN"
+            enrichScope(context = context, player = player, decoderState = decoderState, errorCategory = category, scope = scope)
         }?.toString()
     }
 }
-

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/SentryLogger.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/SentryLogger.kt
@@ -45,16 +45,34 @@ internal object SentryLogger {
             scope.setContexts("Device Info", DeviceInfoProvider.getContext(context))
         } catch (_: Exception) { /* best-effort */ }
 
-        // Storage & memory (needs context)
+        // Storage & memory (needs context) — single pass
         if (context != null) try {
-            StorageMemoryProvider.getTags(context).forEach { (key, value) -> scope.setTag(key, value) }
-            scope.setContexts("Storage & Memory", StorageMemoryProvider.getContext(context))
+            val info = StorageMemoryProvider.getStorageMemoryInfo(context)
+            info.lowMemory?.let { scope.setTag("low_memory", it.toString()) }
+            scope.setContexts("Storage & Memory", buildMap {
+                info.availableRamMb?.let { put("available_ram_mb", it) }
+                info.totalRamMb?.let { put("total_ram_mb", it) }
+                info.availableStorageMb?.let { put("available_storage_mb", it) }
+                info.totalStorageMb?.let { put("total_storage_mb", it) }
+                info.lowMemory?.let { put("low_memory", it) }
+            })
         } catch (_: Exception) { /* best-effort */ }
 
-        // Network info (needs context)
+        // Network info (needs context) — single pass
         if (context != null) try {
-            NetworkInfoProvider.getTags(context).forEach { (key, value) -> scope.setTag(key, value) }
-            scope.setContexts("Network Info", NetworkInfoProvider.getContext(context))
+            val info = NetworkInfoProvider.getNetworkInfo(context)
+            info.networkType?.let { scope.setTag("network_type", it) }
+            info.vpnActive?.let { scope.setTag("vpn_active", it.toString()) }
+            info.networkValidated?.let { scope.setTag("network_validated", it.toString()) }
+            info.operatorName?.let { scope.setTag("operator_name", it) }
+            scope.setContexts("Network Info", buildMap {
+                info.networkType?.let { put("network_type", it) }
+                info.vpnActive?.let { put("vpn_active", it) }
+                info.isRoaming?.let { put("is_roaming", it) }
+                info.networkValidated?.let { put("network_validated", it) }
+                info.activeNetworkMetered?.let { put("active_network_metered", it) }
+                info.operatorName?.let { put("operator_name", it) }
+            })
         } catch (_: Exception) { /* best-effort */ }
 
         // Player state snapshot

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/StorageMemoryProvider.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/StorageMemoryProvider.kt
@@ -13,36 +13,18 @@ import com.tpstreams.player.data.StorageMemoryInfo
  * filesystem I/O (StatFs) and should not be called on the critical UI thread
  * on slow devices.
  *
- * Tags: available_ram_mb, total_ram_mb, available_storage_mb, low_memory
+ * Tags: low_memory
  * Context: all StorageMemoryInfo fields
  */
 internal object StorageMemoryProvider {
 
     private const val BYTES_TO_MB = 1_048_576L
 
-    /** Returns tags for Sentry events (low cardinality only). */
-    fun getTags(context: Context? = null): Map<String, String> {
-        if (context == null) return emptyMap()
-        val info = getStorageMemoryInfo(context)
-        return buildMap {
-            info.lowMemory?.let { put("low_memory", it.toString()) }
-        }
-    }
-
-    /** Returns the full storage/memory context. */
-    fun getContext(context: Context? = null): Map<String, Any> {
-        if (context == null) return emptyMap()
-        val info = getStorageMemoryInfo(context)
-        return buildMap {
-            info.availableRamMb?.let { put("available_ram_mb", it) }
-            info.totalRamMb?.let { put("total_ram_mb", it) }
-            info.availableStorageMb?.let { put("available_storage_mb", it) }
-            info.totalStorageMb?.let { put("total_storage_mb", it) }
-            info.lowMemory?.let { put("low_memory", it) }
-        }
-    }
-
-    private fun getStorageMemoryInfo(context: Context): StorageMemoryInfo {
+    /**
+     * Returns the raw storage/memory info for the given [context].
+     * Use this to avoid redundant I/O when building both tags and context.
+     */
+    internal fun getStorageMemoryInfo(context: Context): StorageMemoryInfo {
         val memInfo = getMemoryInfo(context) ?: return StorageMemoryInfo(
             availableStorageMb = getAvailableStorage(context),
             totalStorageMb = getTotalStorage(context)
@@ -70,7 +52,12 @@ internal object StorageMemoryProvider {
     private fun getAvailableStorage(context: Context): Long? = try {
         val dir = context.filesDir ?: return null
         val stat = StatFs(dir.absolutePath)
-        stat.availableBytes / BYTES_TO_MB
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            stat.availableBytes / BYTES_TO_MB
+        } else {
+            @Suppress("DEPRECATION")
+            (stat.availableBlocks.toLong() * stat.blockSize) / BYTES_TO_MB
+        }
     } catch (_: Exception) {
         null
     }
@@ -78,7 +65,12 @@ internal object StorageMemoryProvider {
     private fun getTotalStorage(context: Context): Long? = try {
         val dir = context.filesDir ?: return null
         val stat = StatFs(dir.absolutePath)
-        stat.totalBytes / BYTES_TO_MB
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            stat.totalBytes / BYTES_TO_MB
+        } else {
+            @Suppress("DEPRECATION")
+            (stat.blockCount.toLong() * stat.blockSize) / BYTES_TO_MB
+        }
     } catch (_: Exception) {
         null
     }

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/StorageMemoryProvider.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/StorageMemoryProvider.kt
@@ -1,0 +1,85 @@
+package com.tpstreams.player.util
+
+import android.app.ActivityManager
+import android.content.Context
+import android.os.StatFs
+import android.os.Build
+import com.tpstreams.player.data.StorageMemoryInfo
+
+/**
+ * Stateless provider of runtime storage and memory information.
+ *
+ * Values are collected fresh on every call. Callers should be aware this does
+ * filesystem I/O (StatFs) and should not be called on the critical UI thread
+ * on slow devices.
+ *
+ * Tags: available_ram_mb, total_ram_mb, available_storage_mb, low_memory
+ * Context: all StorageMemoryInfo fields
+ */
+internal object StorageMemoryProvider {
+
+    private const val BYTES_TO_MB = 1_048_576L
+
+    /** Returns tags for Sentry events (low cardinality only). */
+    fun getTags(context: Context? = null): Map<String, String> {
+        if (context == null) return emptyMap()
+        val info = getStorageMemoryInfo(context)
+        return buildMap {
+            info.lowMemory?.let { put("low_memory", it.toString()) }
+        }
+    }
+
+    /** Returns the full storage/memory context. */
+    fun getContext(context: Context? = null): Map<String, Any> {
+        if (context == null) return emptyMap()
+        val info = getStorageMemoryInfo(context)
+        return buildMap {
+            info.availableRamMb?.let { put("available_ram_mb", it) }
+            info.totalRamMb?.let { put("total_ram_mb", it) }
+            info.availableStorageMb?.let { put("available_storage_mb", it) }
+            info.totalStorageMb?.let { put("total_storage_mb", it) }
+            info.lowMemory?.let { put("low_memory", it) }
+        }
+    }
+
+    private fun getStorageMemoryInfo(context: Context): StorageMemoryInfo {
+        val memInfo = getMemoryInfo(context) ?: return StorageMemoryInfo(
+            availableStorageMb = getAvailableStorage(context),
+            totalStorageMb = getTotalStorage(context)
+        )
+        return StorageMemoryInfo(
+            availableRamMb = memInfo.availMem / BYTES_TO_MB,
+            totalRamMb = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+                memInfo.totalMem / BYTES_TO_MB
+            } else null,
+            lowMemory = memInfo.lowMemory,
+            availableStorageMb = getAvailableStorage(context),
+            totalStorageMb = getTotalStorage(context)
+        )
+    }
+
+    private fun getMemoryInfo(context: Context): ActivityManager.MemoryInfo? = try {
+        val am = context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager ?: return null
+        val memInfo = ActivityManager.MemoryInfo()
+        am.getMemoryInfo(memInfo)
+        memInfo
+    } catch (_: Exception) {
+        null
+    }
+
+    private fun getAvailableStorage(context: Context): Long? = try {
+        val dir = context.filesDir ?: return null
+        val stat = StatFs(dir.absolutePath)
+        stat.availableBytes / BYTES_TO_MB
+    } catch (_: Exception) {
+        null
+    }
+
+    private fun getTotalStorage(context: Context): Long? = try {
+        val dir = context.filesDir ?: return null
+        val stat = StatFs(dir.absolutePath)
+        stat.totalBytes / BYTES_TO_MB
+    } catch (_: Exception) {
+        null
+    }
+}


### PR DESCRIPTION
- Sentry events lacked device, network, storage, and decoder context, making it difficult to triage playback failures across different device configurations.
- Only a few basic tags (playerId, assetId, drmLicenseUrl) were attached to Sentry events — no device, network, or runtime state was captured.
- Added permission-free provider modules (DeviceInfoProvider, NetworkInfoProvider, StorageMemoryProvider, DecoderInfoProvider, PlayerStateSnapshot) that enrich every Sentry event via a centralized enrichScope() method, covering 30+ new fields across device hardware, network connectivity, memory/storage, decoder state, and player snapshot.