### PR TITLE
feat: Add error code tags to Sentry events

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/SentryLogger.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/SentryLogger.kt
@@ -105,7 +105,7 @@ internal object SentryLogger {
                 scope.setTag(key, value)
             }
             scope.setTag("errorCode", error.errorCode.toString())
-            error.errorCodeName?.let { scope.setTag("errorCodeName", it) }
+            scope.setTag("errorCodeName", error.errorCodeName)
             scope.setContexts("Clock Drift", ClockDriftDiagnostics.buildSentryClockContext(nowEpochMs))
             scope.setTag("playerId", playerId)
             assetId?.let { scope.setTag("assetId", it) }
@@ -115,7 +115,7 @@ internal object SentryLogger {
                 "TPStreamsPlayer",
                 mapOf(
                     "Error Code" to error.errorCode,
-                    "Error Code Name" to (error.errorCodeName ?: "N/A"),
+                    "Error Code Name" to error.errorCodeName,
                     "Asset ID" to (assetId ?: "N/A"),
                     "Player ID" to playerId,
                     "DRM License URL" to (drmLicenseUrl?.takeIf { it.isNotEmpty() } ?: "N/A")

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/SentryLogger.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/SentryLogger.kt
@@ -104,6 +104,8 @@ internal object SentryLogger {
             ClockDriftDiagnostics.buildSentryClockTags(nowEpochMs).forEach { (key, value) ->
                 scope.setTag(key, value)
             }
+            scope.setTag("errorCode", error.errorCode.toString())
+            error.errorCodeName?.let { scope.setTag("errorCodeName", it) }
             scope.setContexts("Clock Drift", ClockDriftDiagnostics.buildSentryClockContext(nowEpochMs))
             scope.setTag("playerId", playerId)
             assetId?.let { scope.setTag("assetId", it) }
@@ -113,7 +115,7 @@ internal object SentryLogger {
                 "TPStreamsPlayer",
                 mapOf(
                     "Error Code" to error.errorCode,
-                    "Error Code Name" to error.errorCodeName,
+                    "Error Code Name" to (error.errorCodeName ?: "N/A"),
                     "Asset ID" to (assetId ?: "N/A"),
                     "Player ID" to playerId,
                     "DRM License URL" to (drmLicenseUrl?.takeIf { it.isNotEmpty() } ?: "N/A")


### PR DESCRIPTION
- Error codes from playback failures were only visible inside event context details, not searchable as tags.
- errorCode and errorCodeName were set in Sentry contexts but never as tags.
- Added both as tags so they can be filtered and searched in Sentry's dashboard.