### PR TITLE
feat: Enable screen capture protection for all video playback

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -104,6 +104,10 @@ private constructor(
 
     private var isPrepared = false
     private var drmLicenseUrl: String? = null
+
+    /** True once the DRM license URL has been resolved, i.e. the current asset is DRM-protected. */
+    val isDrmContent: Boolean
+        get() = drmLicenseUrl != null
     private var requestedPlay = false
     private var hasSeekedToStartAt = false
     private var subtitleMetadata = mapOf<String, Boolean>()

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -105,9 +105,14 @@ private constructor(
     private var isPrepared = false
     private var drmLicenseUrl: String? = null
 
-    /** True once the DRM license URL has been resolved, i.e. the current asset is DRM-protected. */
+    /** True when the current asset is DRM-protected.
+     *
+     * Covers two cases:
+     * - Online streaming: drmLicenseUrl is set during preparePlayer.
+     * - Offline downloads: preparePlayer is bypassed, so drmLicenseUrl is never set;
+     *   instead we detect DRM via the media item's DRM configuration. */
     val isDrmContent: Boolean
-        get() = drmLicenseUrl != null
+        get() = drmLicenseUrl != null || currentMediaItem?.localConfiguration?.drmConfiguration != null
     private var requestedPlay = false
     private var hasSeekedToStartAt = false
     private var subtitleMetadata = mapOf<String, Boolean>()

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -105,12 +105,17 @@ private constructor(
     private var isPrepared = false
     private var drmLicenseUrl: String? = null
 
-    /** True when the current asset is DRM-protected.
+    /**
+     * True when the current asset is DRM-protected.
      *
      * Covers two cases:
-     * - Online streaming: drmLicenseUrl is set during preparePlayer.
-     * - Offline downloads: preparePlayer is bypassed, so drmLicenseUrl is never set;
-     *   instead we detect DRM via the media item's DRM configuration. */
+     * - Online streaming: [drmLicenseUrl] is set during [preparePlayer].
+     * - Offline downloads: [preparePlayer] is bypassed, so [drmLicenseUrl] is never set;
+     *   instead we detect DRM via the media item's DRM configuration.
+     *
+     * Note: [TPStreamsPlayerView] applies FLAG_SECURE for all playback (DRM and non-DRM).
+     * This property is exposed for host-app use cases such as conditional UI or analytics.
+     */
     val isDrmContent: Boolean
         get() = drmLicenseUrl != null || currentMediaItem?.localConfiguration?.drmConfiguration != null
     private var requestedPlay = false

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
@@ -56,7 +56,7 @@ class TPStreamsPlayerView @JvmOverloads constructor(
     private var retryLoader: View? = null
     private var retryIndicator: TextView? = null
     private var bufferingView: View? = null
-    private var isSecureFlagApplied = false
+    private var hasAcquiredSecureFlag = false
     
     private val liveBadge: View? by lazy { findViewById(R.id.live_badge) }
     private val durationView: View? by lazy { findViewById(androidx.media3.ui.R.id.exo_duration) }
@@ -179,6 +179,12 @@ class TPStreamsPlayerView @JvmOverloads constructor(
         getPlayer()?.addListener(playbackStateListener)
         ensureErrorOverlaySetup()
         
+        // Re-apply FLAG_SECURE if the player has DRM content — handles the fullscreen transition
+        // where the view is temporarily detached from its parent and re-attached to the decor view.
+        if ((getPlayer() as? TPStreamsPlayer)?.isDrmContent == true) {
+            applySecureFlag()
+        }
+
         post {
             if (autoFullscreenOnRotateEnabled) {
                 enableAutoFullscreenOnRotate()
@@ -386,6 +392,11 @@ class TPStreamsPlayerView @JvmOverloads constructor(
         lifecycleManager = player?.let { PlayerLifecycleManager(it) }
         registerWithLifecycle()
         
+        if (player == null) {
+            // Explicitly clear FLAG_SECURE when the player is released to prevent it from
+            // leaking to unrelated screens in a Single-Activity architecture.
+            removeSecureFlag()
+        }
         if (player != null) {
             // Apply FLAG_SECURE only for DRM-protected content to block screen recording.
             // Non-DRM content must not be gated — it would block fullscreen for all videos.
@@ -510,11 +521,11 @@ class TPStreamsPlayerView @JvmOverloads constructor(
         unregisterFromLifecycle()
         disableAutoFullscreenOnRotate()
         
-        // Remove FLAG_SECURE only if the Activity is finishing (permanent removal)
-        // During fullscreen transitions, the view is temporarily detached but the Activity is still alive
-        if (getActivity()?.isFinishing == true) {
-            removeSecureFlag()
-        }
+        // Always remove FLAG_SECURE on detach. In a Single-Activity architecture the Activity
+        // is rarely finishing during normal navigation, so guarding on isFinishing would leak
+        // the flag to unrelated screens. onAttachedToWindow() re-applies it when the view is
+        // re-attached for fullscreen transitions.
+        removeSecureFlag()
     }
 
     // Implementation of PlayerSettingsBottomSheet.SettingsListener
@@ -789,22 +800,59 @@ class TPStreamsPlayerView @JvmOverloads constructor(
 
     companion object {
         private const val TAG = "TPStreamsPlayerView"
+
+        /**
+         * Tracks how many DRM-playing views are active per Activity.
+         *
+         * FLAG_SECURE is a window-level flag shared by all views in an Activity. Using a simple
+         * per-view boolean to track it causes two bugs in multi-view or Single-Activity scenarios:
+         *   1. One view's removeSecureFlag() clears the flag while another view still needs it
+         *      (security regression — DRM content becomes screenshot-capable).
+         *   2. When a DRM view is detached during navigation without the Activity finishing, the
+         *      flag stays on unrelated screens (functional regression — screenshots blocked
+         *      everywhere).
+         *
+         * Solution: ref-count acquisitions per Activity. FLAG_SECURE is set when count rises to 1
+         * and cleared only when it drops back to 0. WeakHashMap ensures finished Activities
+         * are not leaked.
+         */
+        private val drmViewCountByActivity = java.util.WeakHashMap<androidx.fragment.app.FragmentActivity, Int>()
+
+        private fun acquireSecureFlag(activity: androidx.fragment.app.FragmentActivity) {
+            val count = (drmViewCountByActivity[activity] ?: 0) + 1
+            drmViewCountByActivity[activity] = count
+            if (count == 1) {
+                activity.window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+                Log.d(TAG, "FLAG_SECURE set (DRM view count: 1)")
+            } else {
+                Log.d(TAG, "FLAG_SECURE already set (DRM view count: $count)")
+            }
+        }
+
+        private fun releaseSecureFlag(activity: androidx.fragment.app.FragmentActivity) {
+            val count = ((drmViewCountByActivity[activity] ?: 0) - 1).coerceAtLeast(0)
+            if (count == 0) {
+                drmViewCountByActivity.remove(activity)
+                activity.window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+                Log.d(TAG, "FLAG_SECURE cleared (no active DRM views)")
+            } else {
+                drmViewCountByActivity[activity] = count
+                Log.d(TAG, "FLAG_SECURE kept (DRM view count: $count)")
+            }
+        }
     }
     
     private fun applySecureFlag() {
-        if (isSecureFlagApplied) return
+        if (hasAcquiredSecureFlag) return
         val activity = getActivity() ?: return
-        activity.window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
-        isSecureFlagApplied = true
-        Log.d(TAG, "Screen Capture Protection Enabled")
-        Log.d(TAG, "FLAG_SECURE = true")
+        hasAcquiredSecureFlag = true
+        acquireSecureFlag(activity)
     }
-    
+
     private fun removeSecureFlag() {
-        if (!isSecureFlagApplied) return
+        if (!hasAcquiredSecureFlag) return
         val activity = getActivity() ?: return
-        activity.window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
-        isSecureFlagApplied = false
-        Log.d(TAG, "Screen Capture Protection Disabled")
+        hasAcquiredSecureFlag = false
+        releaseSecureFlag(activity)
     }
 }

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
@@ -179,9 +179,9 @@ class TPStreamsPlayerView @JvmOverloads constructor(
         getPlayer()?.addListener(playbackStateListener)
         ensureErrorOverlaySetup()
         
-        // Re-apply FLAG_SECURE if the player has DRM content — handles the fullscreen transition
-        // where the view is temporarily detached from its parent and re-attached to the decor view.
-        if ((getPlayer() as? TPStreamsPlayer)?.isDrmContent == true) {
+        // Re-apply FLAG_SECURE on re-attach — handles fullscreen transitions where the view is
+        // temporarily detached from its parent and re-parented to the decor view.
+        if (getPlayer() != null) {
             applySecureFlag()
         }
 
@@ -393,18 +393,12 @@ class TPStreamsPlayerView @JvmOverloads constructor(
         registerWithLifecycle()
         
         if (player == null) {
-            // Explicitly clear FLAG_SECURE when the player is released to prevent it from
-            // leaking to unrelated screens in a Single-Activity architecture.
+            // Explicitly clear FLAG_SECURE when the player is released.
             removeSecureFlag()
         }
         if (player != null) {
-            // Apply FLAG_SECURE only for DRM-protected content to block screen recording.
-            // Non-DRM content must not be gated — it would block fullscreen for all videos.
-            if ((player as? TPStreamsPlayer)?.isDrmContent == true) {
-                applySecureFlag()
-            } else {
-                removeSecureFlag()
-            }
+            // Apply FLAG_SECURE for all playback to block screen recording and screenshots.
+            applySecureFlag()
             when (player.playbackState) {
                 Player.STATE_IDLE -> {
                     showLoading()
@@ -461,17 +455,6 @@ class TPStreamsPlayerView @JvmOverloads constructor(
                 if (player.startInFullscreen) {
                     fullscreenMode.enterFullscreen()
                 }
-                
-                player.addListener(object : Player.Listener {
-                    override fun onPlaybackStateChanged(playbackState: Int) {
-                        if (playbackState == Player.STATE_READY) {
-                            updateLiveStreamUI(player.isLiveStream)
-                            // Re-evaluate FLAG_SECURE now that DRM info is resolved.
-                            // drmLicenseUrl is populated during preparePlayer, before STATE_READY.
-                            if (player.isDrmContent) applySecureFlag() else removeSecureFlag()
-                        }
-                    }
-                })
             }
         } else {
             hideErrorMessage()

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
@@ -9,6 +9,7 @@ import android.text.method.LinkMovementMethod
 import android.util.AttributeSet
 import android.util.Log
 import android.view.View
+import android.view.WindowManager
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.media3.common.Player
@@ -55,6 +56,7 @@ class TPStreamsPlayerView @JvmOverloads constructor(
     private var retryLoader: View? = null
     private var retryIndicator: TextView? = null
     private var bufferingView: View? = null
+    private var isSecureFlagApplied = false
     
     private val liveBadge: View? by lazy { findViewById(R.id.live_badge) }
     private val durationView: View? by lazy { findViewById(androidx.media3.ui.R.id.exo_duration) }
@@ -385,6 +387,13 @@ class TPStreamsPlayerView @JvmOverloads constructor(
         registerWithLifecycle()
         
         if (player != null) {
+            // Apply FLAG_SECURE only for DRM-protected content to block screen recording.
+            // Non-DRM content must not be gated — it would block fullscreen for all videos.
+            if ((player as? TPStreamsPlayer)?.isDrmContent == true) {
+                applySecureFlag()
+            } else {
+                removeSecureFlag()
+            }
             when (player.playbackState) {
                 Player.STATE_IDLE -> {
                     showLoading()
@@ -446,6 +455,9 @@ class TPStreamsPlayerView @JvmOverloads constructor(
                     override fun onPlaybackStateChanged(playbackState: Int) {
                         if (playbackState == Player.STATE_READY) {
                             updateLiveStreamUI(player.isLiveStream)
+                            // Re-evaluate FLAG_SECURE now that DRM info is resolved.
+                            // drmLicenseUrl is populated during preparePlayer, before STATE_READY.
+                            if (player.isDrmContent) applySecureFlag() else removeSecureFlag()
                         }
                     }
                 })
@@ -497,6 +509,12 @@ class TPStreamsPlayerView @JvmOverloads constructor(
         getPlayer()?.removeListener(playbackStateListener)
         unregisterFromLifecycle()
         disableAutoFullscreenOnRotate()
+        
+        // Remove FLAG_SECURE only if the Activity is finishing (permanent removal)
+        // During fullscreen transitions, the view is temporarily detached but the Activity is still alive
+        if (getActivity()?.isFinishing == true) {
+            removeSecureFlag()
+        }
     }
 
     // Implementation of PlayerSettingsBottomSheet.SettingsListener
@@ -771,5 +789,22 @@ class TPStreamsPlayerView @JvmOverloads constructor(
 
     companion object {
         private const val TAG = "TPStreamsPlayerView"
+    }
+    
+    private fun applySecureFlag() {
+        if (isSecureFlagApplied) return
+        val activity = getActivity() ?: return
+        activity.window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        isSecureFlagApplied = true
+        Log.d(TAG, "Screen Capture Protection Enabled")
+        Log.d(TAG, "FLAG_SECURE = true")
+    }
+    
+    private fun removeSecureFlag() {
+        if (!isSecureFlagApplied) return
+        val activity = getActivity() ?: return
+        activity.window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        isSecureFlagApplied = false
+        Log.d(TAG, "Screen Capture Protection Disabled")
     }
 }

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
@@ -785,42 +785,44 @@ class TPStreamsPlayerView @JvmOverloads constructor(
         private const val TAG = "TPStreamsPlayerView"
 
         /**
-         * Tracks how many DRM-playing views are active per Activity.
+         * Tracks how many player views are active per Activity.
          *
          * FLAG_SECURE is a window-level flag shared by all views in an Activity. Using a simple
          * per-view boolean to track it causes two bugs in multi-view or Single-Activity scenarios:
          *   1. One view's removeSecureFlag() clears the flag while another view still needs it
-         *      (security regression — DRM content becomes screenshot-capable).
-         *   2. When a DRM view is detached during navigation without the Activity finishing, the
-         *      flag stays on unrelated screens (functional regression — screenshots blocked
-         *      everywhere).
+         *      (regression — video content becomes screenshot/recording-capable).
+         *   2. When a view is detached during navigation without the Activity finishing, the
+         *      flag stays on unrelated screens (regression — screenshots blocked everywhere).
          *
          * Solution: ref-count acquisitions per Activity. FLAG_SECURE is set when count rises to 1
          * and cleared only when it drops back to 0. WeakHashMap ensures finished Activities
          * are not leaked.
+         *
+         * FLAG_SECURE is applied for all playback (DRM and non-DRM) to uniformly prevent
+         * screen recording and screenshots while a player is on screen.
          */
-        private val drmViewCountByActivity = java.util.WeakHashMap<androidx.fragment.app.FragmentActivity, Int>()
+        private val activePlayerViewCountByActivity = java.util.WeakHashMap<androidx.fragment.app.FragmentActivity, Int>()
 
         private fun acquireSecureFlag(activity: androidx.fragment.app.FragmentActivity) {
-            val count = (drmViewCountByActivity[activity] ?: 0) + 1
-            drmViewCountByActivity[activity] = count
+            val count = (activePlayerViewCountByActivity[activity] ?: 0) + 1
+            activePlayerViewCountByActivity[activity] = count
             if (count == 1) {
                 activity.window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
-                Log.d(TAG, "FLAG_SECURE set (DRM view count: 1)")
+                Log.d(TAG, "FLAG_SECURE set (active player views: 1)")
             } else {
-                Log.d(TAG, "FLAG_SECURE already set (DRM view count: $count)")
+                Log.d(TAG, "FLAG_SECURE already set (active player views: $count)")
             }
         }
 
         private fun releaseSecureFlag(activity: androidx.fragment.app.FragmentActivity) {
-            val count = ((drmViewCountByActivity[activity] ?: 0) - 1).coerceAtLeast(0)
+            val count = ((activePlayerViewCountByActivity[activity] ?: 0) - 1).coerceAtLeast(0)
             if (count == 0) {
-                drmViewCountByActivity.remove(activity)
+                activePlayerViewCountByActivity.remove(activity)
                 activity.window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
-                Log.d(TAG, "FLAG_SECURE cleared (no active DRM views)")
+                Log.d(TAG, "FLAG_SECURE cleared (no active player views)")
             } else {
-                drmViewCountByActivity[activity] = count
-                Log.d(TAG, "FLAG_SECURE kept (DRM view count: $count)")
+                activePlayerViewCountByActivity[activity] = count
+                Log.d(TAG, "FLAG_SECURE kept (active player views: $count)")
             }
         }
     }

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
@@ -56,8 +56,8 @@ class TPStreamsPlayerView @JvmOverloads constructor(
     private var retryLoader: View? = null
     private var retryIndicator: TextView? = null
     private var bufferingView: View? = null
-    private var hasAcquiredSecureFlag = false
     
+
     private val liveBadge: View? by lazy { findViewById(R.id.live_badge) }
     private val durationView: View? by lazy { findViewById(androidx.media3.ui.R.id.exo_duration) }
     private val separatorView: View? by lazy { findViewById(R.id.exo_time_separator) }
@@ -827,17 +827,18 @@ class TPStreamsPlayerView @JvmOverloads constructor(
         }
     }
     
+    private var secureFlagActivity: androidx.fragment.app.FragmentActivity? = null
+
     private fun applySecureFlag() {
-        if (hasAcquiredSecureFlag) return
+        if (secureFlagActivity != null) return
         val activity = getActivity() ?: return
-        hasAcquiredSecureFlag = true
+        secureFlagActivity = activity
         acquireSecureFlag(activity)
     }
 
     private fun removeSecureFlag() {
-        if (!hasAcquiredSecureFlag) return
-        val activity = getActivity() ?: return
-        hasAcquiredSecureFlag = false
+        val activity = secureFlagActivity ?: return
+        secureFlagActivity = null
         releaseSecureFlag(activity)
     }
 }


### PR DESCRIPTION
- Videos could still be captured through screenshots or screen recording on supported devices, reducing the effectiveness of content protection.
- This happened because secure display protection was not enabled during playback.
- This is fixed by unconditionally enabling screen capture protection for all video playback, ensuring content cannot be captured. Protection is automatically applied when a player is active and safely removed when it is released or detached.