### PR TITLE
feat!: redesign watermark API for multiple watermarks and backend alignment

### DIFF
--- a/app/src/main/java/com/tpstreams/player/PlayerActivity.kt
+++ b/app/src/main/java/com/tpstreams/player/PlayerActivity.kt
@@ -30,16 +30,32 @@ class PlayerActivity : AppCompatActivity() {
         binding.playerView.player = viewModel.player
 
 
-        binding.playerView.setWatermark(
-            WatermarkConfig(
-                text = "© 2026 TPstreams",
-                color = Color.YELLOW,
-                textSize = 18f,
-                opacity = 0.5f,
-                position = WatermarkPosition.CENTER_LEFT,
-                animation = WatermarkAnimation(
-                    type = WatermarkAnimationType.PING_PONG,
-                    duration = 5_000L,
+        binding.playerView.setWatermarks(
+            listOf(
+                WatermarkConfig(
+                    text = "This is a watermark",
+                    x = 0,
+                    y = 50,
+                    color = Color.YELLOW,
+                    textSize = 18f,
+                    opacity = 0.5f,
+                    animation = WatermarkAnimation(
+                        type = WatermarkAnimationType.PING_PONG,
+                        duration = 5_000L,
+                    ),
+                ),
+                WatermarkConfig(
+                    text = "Test 1",
+                    x = 100,
+                    y = 100,
+                    opacity = 0.2f,
+                ),
+                WatermarkConfig(
+                    text = "Test 2",
+                    x = 0,
+                    y = 0,
+                    opacity = 1f,
+                    animation = WatermarkAnimation(type = WatermarkAnimationType.PING_PONG,duration = 10000L)
                 ),
             )
         )

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
@@ -40,7 +40,7 @@ class TPStreamsPlayerView @JvmOverloads constructor(
     private val settingsPanel = SettingsPanel(this)
     private val captions = Captions(this)
     private val contextAccess = ContextAccess(this)
-    private val watermarkControllers = mutableMapOf<String, WatermarkController>()
+    private val watermarkControllers = mutableListOf<WatermarkController>()
     
     private var playerControlView: TPStreamsPlayerControlView? = null
     private var orientationEventListener: OrientationListener? = null
@@ -193,7 +193,7 @@ class TPStreamsPlayerView @JvmOverloads constructor(
                 enableAutoFullscreenOnRotate()
             }
             registerWithLifecycle()
-            watermarkControllers.values.forEach { it.onViewAttached() }
+            watermarkControllers.forEach { it.onViewAttached() }
         }
     }
 
@@ -487,7 +487,7 @@ class TPStreamsPlayerView @JvmOverloads constructor(
         super.onLayout(changed, left, top, right, bottom)
         
         // Reposition watermark on layout changes (fullscreen, rotation, resize)
-        watermarkControllers.values.forEach { it.onParentLayout() }
+        watermarkControllers.forEach { it.onParentLayout() }
         
         // Ensure error overlay is properly laid out when view is measured
         errorOverlay?.let { overlay ->
@@ -510,7 +510,7 @@ class TPStreamsPlayerView @JvmOverloads constructor(
         getPlayer()?.removeListener(playbackStateListener)
         unregisterFromLifecycle()
         disableAutoFullscreenOnRotate()
-        watermarkControllers.values.forEach { it.onViewDetached() }
+        watermarkControllers.forEach { it.onViewDetached() }
         
         // Always remove FLAG_SECURE on detach. In a Single-Activity architecture the Activity
         // is rarely finishing during normal navigation, so guarding on isFinishing would leak
@@ -775,18 +775,18 @@ class TPStreamsPlayerView @JvmOverloads constructor(
     // ── Watermark ────────────────────────────────────────────────────────
 
     fun setWatermarks(configs: List<WatermarkConfig>) {
-        watermarkControllers.values.forEach { it.destroy() }
+        watermarkControllers.forEach { it.destroy() }
         watermarkControllers.clear()
 
-        configs.forEachIndexed { index, config ->
+        configs.forEach { config ->
             val controller = WatermarkController(this)
-            watermarkControllers[index.toString()] = controller
+            watermarkControllers.add(controller)
             controller.apply(config)
         }
     }
 
     fun clearWatermarks() {
-        watermarkControllers.values.forEach { it.destroy() }
+        watermarkControllers.forEach { it.destroy() }
         watermarkControllers.clear()
     }
 
@@ -801,7 +801,7 @@ class TPStreamsPlayerView @JvmOverloads constructor(
 
     private fun notifyWatermarkPlayerState() {
         val player = getPlayer() ?: return
-        watermarkControllers.values.forEach {
+        watermarkControllers.forEach {
             it.onPlayerStateChanged(
                 isPlaying = player.isPlaying,
                 playbackState = player.playbackState

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
@@ -40,7 +40,7 @@ class TPStreamsPlayerView @JvmOverloads constructor(
     private val settingsPanel = SettingsPanel(this)
     private val captions = Captions(this)
     private val contextAccess = ContextAccess(this)
-    private var watermarkController: WatermarkController? = null
+    private val watermarkControllers = mutableMapOf<String, WatermarkController>()
     
     private var playerControlView: TPStreamsPlayerControlView? = null
     private var orientationEventListener: OrientationListener? = null
@@ -193,7 +193,7 @@ class TPStreamsPlayerView @JvmOverloads constructor(
                 enableAutoFullscreenOnRotate()
             }
             registerWithLifecycle()
-            watermarkController?.onViewAttached()
+            watermarkControllers.values.forEach { it.onViewAttached() }
         }
     }
 
@@ -487,7 +487,7 @@ class TPStreamsPlayerView @JvmOverloads constructor(
         super.onLayout(changed, left, top, right, bottom)
         
         // Reposition watermark on layout changes (fullscreen, rotation, resize)
-        watermarkController?.onParentLayout()
+        watermarkControllers.values.forEach { it.onParentLayout() }
         
         // Ensure error overlay is properly laid out when view is measured
         errorOverlay?.let { overlay ->
@@ -510,7 +510,7 @@ class TPStreamsPlayerView @JvmOverloads constructor(
         getPlayer()?.removeListener(playbackStateListener)
         unregisterFromLifecycle()
         disableAutoFullscreenOnRotate()
-        watermarkController?.onViewDetached()
+        watermarkControllers.values.forEach { it.onViewDetached() }
         
         // Always remove FLAG_SECURE on detach. In a Single-Activity architecture the Activity
         // is rarely finishing during normal navigation, so guarding on isFinishing would leak
@@ -774,34 +774,25 @@ class TPStreamsPlayerView @JvmOverloads constructor(
 
     // ── Watermark ────────────────────────────────────────────────────────
 
-    fun setWatermark(config: WatermarkConfig?) {
-        if (config == null) {
-            watermarkController?.destroy()
-            watermarkController = null
-            return
+    fun setWatermarks(configs: List<WatermarkConfig>) {
+        watermarkControllers.values.forEach { it.destroy() }
+        watermarkControllers.clear()
+
+        configs.forEachIndexed { index, config ->
+            val controller = WatermarkController(this)
+            watermarkControllers[index.toString()] = controller
+            controller.apply(config)
         }
-        if (watermarkController == null) {
-            watermarkController = WatermarkController(this)
-        }
-        watermarkController?.apply(config)
     }
 
-    fun showWatermark() {
-        watermarkController?.show()
-    }
-
-    fun hideWatermark() {
-        watermarkController?.hide()
-    }
-
-    fun removeWatermark() {
-        watermarkController?.destroy()
-        watermarkController = null
+    fun clearWatermarks() {
+        watermarkControllers.values.forEach { it.destroy() }
+        watermarkControllers.clear()
     }
 
     /**
-     * Returns the child index at which the watermark container should be inserted.
-     * Placed before the error overlay so that watermark renders below error/loading UI.
+     * Returns the child index at which watermark containers should be inserted.
+     * Placed before the error overlay so that watermarks render below error/loading UI.
      */
     internal fun getWatermarkInsertIndex(): Int {
         val index = errorOverlay?.let { indexOfChild(it) } ?: -1
@@ -810,10 +801,12 @@ class TPStreamsPlayerView @JvmOverloads constructor(
 
     private fun notifyWatermarkPlayerState() {
         val player = getPlayer() ?: return
-        watermarkController?.onPlayerStateChanged(
-            isPlaying = player.isPlaying,
-            playbackState = player.playbackState
-        )
+        watermarkControllers.values.forEach {
+            it.onPlayerStateChanged(
+                isPlaying = player.isPlaying,
+                playbackState = player.playbackState
+            )
+        }
     }
     
     private fun isDecoderError(message: String): Boolean {

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/WatermarkConfig.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/WatermarkConfig.kt
@@ -4,34 +4,17 @@ import android.graphics.Color
 
 data class WatermarkConfig(
     val text: String,
-    val position: WatermarkPosition = WatermarkPosition.CENTER_LEFT,
+    val x: Int = 0,
+    val y: Int = 0,
     val color: Int = Color.WHITE,
     val textSize: Float = 14f,
     val opacity: Float = 0.3f,
     val animation: WatermarkAnimation? = null,
-)
-
-enum class WatermarkPosition {
-    TOP_LEFT,
-    TOP_CENTER,
-    TOP_RIGHT,
-    CENTER_LEFT,
-    CENTER,
-    CENTER_RIGHT,
-    BOTTOM_LEFT,
-    BOTTOM_CENTER,
-    BOTTOM_RIGHT;
-
-    internal fun toFraction(): Pair<Float, Float> = when (this) {
-        TOP_LEFT      -> 0f to 0f
-        TOP_CENTER    -> 0.5f to 0f
-        TOP_RIGHT     -> 1f to 0f
-        CENTER_LEFT   -> 0f to 0.5f
-        CENTER        -> 0.5f to 0.5f
-        CENTER_RIGHT  -> 1f to 0.5f
-        BOTTOM_LEFT   -> 0f to 1f
-        BOTTOM_CENTER -> 0.5f to 1f
-        BOTTOM_RIGHT  -> 1f to 1f
+) {
+    init {
+        require(x in 0..100) { "x must be 0-100, was $x" }
+        require(y in 0..100) { "y must be 0-100, was $y" }
+        require(opacity in 0f..1f) { "opacity must be 0.0-1.0, was $opacity" }
     }
 }
 

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/WatermarkConfig.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/WatermarkConfig.kt
@@ -2,7 +2,7 @@ package com.tpstreams.player
 
 import android.graphics.Color
 
-data class WatermarkConfig(
+data class WatermarkConfig @JvmOverloads constructor(
     val text: String,
     val x: Int = 0,
     val y: Int = 0,

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/WatermarkController.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/WatermarkController.kt
@@ -13,7 +13,6 @@ internal class WatermarkController(private val parent: TPStreamsPlayerView) {
     private var config: WatermarkConfig? = null
 
     private var currentIsPlaying = false
-    private var hasPlaybackStarted = false
 
     private var pingPongAnimator: ValueAnimator? = null
     private var applyCounter: Int = 0
@@ -29,7 +28,6 @@ internal class WatermarkController(private val parent: TPStreamsPlayerView) {
         val player = parent.getPlayer()
         if (player != null) {
             currentIsPlaying = player.isPlaying
-            hasPlaybackStarted = player.isPlaying
         }
 
         createViews(config)
@@ -43,11 +41,9 @@ internal class WatermarkController(private val parent: TPStreamsPlayerView) {
             if (applyGeneration != applyCounter) return@post
             reposition()
 
-            if (hasPlaybackStarted) {
-                val anim = config.animation
-                if (anim?.type == WatermarkAnimationType.PING_PONG) {
-                    startPingPongAnimation(anim)
-                }
+            val anim = config.animation
+            if (anim?.type == WatermarkAnimationType.PING_PONG) {
+                startPingPongAnimation(anim)
             }
 
             updateVisibilityForState(currentIsPlaying)
@@ -60,7 +56,6 @@ internal class WatermarkController(private val parent: TPStreamsPlayerView) {
         container?.let { parent.removeView(it) }
         container = null
         config = null
-        hasPlaybackStarted = false
     }
 
     fun onParentLayout() {
@@ -69,18 +64,8 @@ internal class WatermarkController(private val parent: TPStreamsPlayerView) {
 
     fun onPlayerStateChanged(isPlaying: Boolean, playbackState: Int = Player.STATE_IDLE) {
         currentIsPlaying = isPlaying
-
-        if (isPlaying && !hasPlaybackStarted) {
-            hasPlaybackStarted = true
-            config?.let { cfg ->
-                val anim = cfg.animation
-                if (anim?.type == WatermarkAnimationType.PING_PONG) {
-                    startPingPongAnimation(anim)
-                }
-            }
-        }
-
-        updateVisibilityForState(isPlaying, playbackState == Player.STATE_ENDED)
+        val hasEnded = playbackState == Player.STATE_ENDED
+        updateVisibilityForState(isPlaying, hasEnded)
     }
 
     fun destroy() {
@@ -92,9 +77,6 @@ internal class WatermarkController(private val parent: TPStreamsPlayerView) {
     }
 
     fun onViewAttached() {
-        if (hasPlaybackStarted) {
-            pingPongAnimator?.resume()
-        }
         updateVisibilityForState(currentIsPlaying)
         reposition()
     }
@@ -180,24 +162,16 @@ internal class WatermarkController(private val parent: TPStreamsPlayerView) {
         c.translationY = y
     }
 
-    // ── Visibility ───────────────────────────────────────────────────────
-    //
-    // Watermark is shown once playback starts. It stays visible while paused
-    // and hides before first play or after playback ends.
+    // Watermark is always visible. The animation pauses when not playing.
 
     private fun updateVisibilityForState(isPlaying: Boolean, hasEnded: Boolean = false) {
-        if (!hasPlaybackStarted || hasEnded) {
-            container?.visibility = View.GONE
-            pingPongAnimator?.let { if (it.isRunning) it.pause() }
-            return
-        }
-
         container?.visibility = View.VISIBLE
 
         pingPongAnimator?.let { animator ->
-            if (isPlaying && animator.isPaused) {
+            val shouldAnimate = isPlaying && !hasEnded
+            if (shouldAnimate && animator.isPaused) {
                 animator.resume()
-            } else if (!isPlaying && animator.isRunning) {
+            } else if (!shouldAnimate && animator.isRunning) {
                 animator.pause()
             }
         }

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/WatermarkController.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/WatermarkController.kt
@@ -12,7 +12,6 @@ internal class WatermarkController(private val parent: TPStreamsPlayerView) {
     private var container: FrameLayout? = null
     private var config: WatermarkConfig? = null
 
-    private var manualVisibility: Boolean? = null
     private var currentIsPlaying = false
     private var hasPlaybackStarted = false
 
@@ -55,25 +54,12 @@ internal class WatermarkController(private val parent: TPStreamsPlayerView) {
         }
     }
 
-    fun show() {
-        manualVisibility = true
-        container?.visibility = View.VISIBLE
-        pingPongAnimator?.resume()
-    }
-
-    fun hide() {
-        manualVisibility = false
-        container?.visibility = View.GONE
-        pingPongAnimator?.pause()
-    }
-
     fun remove() {
         pingPongAnimator?.cancel()
         pingPongAnimator = null
         container?.let { parent.removeView(it) }
         container = null
         config = null
-        manualVisibility = null
         hasPlaybackStarted = false
     }
 
@@ -200,8 +186,6 @@ internal class WatermarkController(private val parent: TPStreamsPlayerView) {
     // and hides before first play or after playback ends.
 
     private fun updateVisibilityForState(isPlaying: Boolean, hasEnded: Boolean = false) {
-        if (manualVisibility != null) return
-
         if (!hasPlaybackStarted || hasEnded) {
             container?.visibility = View.GONE
             pingPongAnimator?.let { if (it.isRunning) it.pause() }

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/WatermarkController.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/WatermarkController.kt
@@ -153,7 +153,7 @@ internal class WatermarkController(private val parent: TPStreamsPlayerView) {
         if (c.width == 0 || c.height == 0) return
 
         val animXy = getAnimationCurrentPosition()
-        val (xFrac, yFrac) = animXy ?: cfg.position.toFraction()
+        val (xFrac, yFrac) = animXy ?: (cfg.x / 100f to cfg.y / 100f)
 
         placeAt(xFrac, yFrac)
     }
@@ -163,7 +163,7 @@ internal class WatermarkController(private val parent: TPStreamsPlayerView) {
         if (!animator.isRunning && !animator.isPaused) return null
         val fraction = animator.animatedValue as? Float ?: return null
         val cfg = config ?: return null
-        val yFrac = cfg.position.toFraction().second
+        val yFrac = cfg.y / 100f
         return fraction to yFrac
     }
 


### PR DESCRIPTION
- The existing watermark API only supported a single watermark, making it difficult to align with the backend configuration and support more advanced watermark layouts.
- Redesigned the API to support multiple watermarks through a declarative setWatermarks(...) interface.
- Replaced predefined positions with relative x/y coordinates to provide a more flexible and backend-compatible positioning model.
- Simplified the watermark configuration model and added validation to prevent invalid coordinate and opacity values.
- Updated the player implementation and sample application to demonstrate multiple watermarks rendered simultaneously.