### PR TITLE
feat: Resume playback from last watched position

### DIFF
--- a/app/src/main/java/com/tpstreams/player/MainActivity.kt
+++ b/app/src/main/java/com/tpstreams/player/MainActivity.kt
@@ -77,6 +77,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun initTPStreams() {
         TPStreamsSDK.init("9q94nm", TPStreamsSDK.Provider.TPStreams)
+        TPStreamsSDK.userId = "kaizen"
     }
 
     private fun initTestpress() {

--- a/app/src/main/java/com/tpstreams/player/MainActivity.kt
+++ b/app/src/main/java/com/tpstreams/player/MainActivity.kt
@@ -77,7 +77,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun initTPStreams() {
         TPStreamsSDK.init("9q94nm", TPStreamsSDK.Provider.TPStreams)
-        TPStreamsSDK.userId = "kaizen"
+        TPStreamsSDK.userId = "test_user"
     }
 
     private fun initTestpress() {

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/ResumePlaybackManager.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/ResumePlaybackManager.kt
@@ -1,0 +1,113 @@
+package com.tpstreams.player
+
+import androidx.media3.common.Player
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+
+internal class ResumePlaybackManager(
+    private val player: Player,
+    private val assetId: String
+) {
+
+    companion object {
+        private const val RESUME_PLAYBACK_BASE_URL = "https://data.tpstreams.com/api/player"
+        private const val LAST_WATCHED_POSITION_URL = "$RESUME_PLAYBACK_BASE_URL/last-watched-position/"
+        private const val UPDATE_WATCHED_POSITION_URL = "$RESUME_PLAYBACK_BASE_URL/update-watched-position/"
+        private const val SAVE_INTERVAL_MS = 2 * 60 * 1000L
+        private val client = OkHttpClient()
+        private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
+
+        private fun watchPositionBody(userId: String, orgId: String, assetId: String): JSONObject =
+            JSONObject().apply {
+                put("user_id", userId)
+                put("organization_id", orgId)
+                put("asset_id", assetId)
+            }
+
+        private fun updateBody(userId: String, orgId: String, assetId: String, watchedSeconds: Int): JSONObject =
+            watchPositionBody(userId, orgId, assetId).put("watched_seconds", watchedSeconds)
+    }
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var fetched = false
+
+    private val periodicSaveJob = scope.launch {
+        while (isActive) {
+            delay(SAVE_INTERVAL_MS)
+            if (player.isPlaying) saveWatchedPosition()
+        }
+    }
+
+    fun onPlayerReady() {
+        if (fetched) return
+        fetched = true
+        val userId = TPStreamsSDK.userId ?: return
+        val orgId = TPStreamsSDK.orgId ?: return
+        val body = watchPositionBody(userId, orgId, assetId)
+        scope.launch {
+            val response = post(LAST_WATCHED_POSITION_URL, body) ?: return@launch
+            val seconds = response.optInt("watched_seconds", 0)
+            if (seconds > 0) {
+                withContext(Dispatchers.Main) { player.seekTo(seconds * 1000L) }
+            }
+        }
+    }
+
+    fun onPaused() = saveWatchedPosition()
+
+    fun onSeeked() = saveWatchedPosition()
+
+    fun onVideoEnded() {
+        periodicSaveJob.cancel()
+        val userId = TPStreamsSDK.userId ?: return
+        val orgId = TPStreamsSDK.orgId ?: return
+        scope.launch { delete(LAST_WATCHED_POSITION_URL, watchPositionBody(userId, orgId, assetId)) }
+    }
+
+    fun onRelease() {
+        saveWatchedPosition(allowCancellation = false)
+        scope.cancel()
+    }
+
+    private fun saveWatchedPosition(allowCancellation: Boolean = true) {
+        val userId = TPStreamsSDK.userId ?: return
+        val orgId = TPStreamsSDK.orgId ?: return
+        if (player.playbackState == Player.STATE_ENDED) return
+        val body = updateBody(userId, orgId, assetId, (player.currentPosition / 1000).toInt())
+        val context = if (allowCancellation) Dispatchers.IO else NonCancellable + Dispatchers.IO
+        scope.launch(context) { post(UPDATE_WATCHED_POSITION_URL, body) }
+    }
+
+    private fun post(url: String, body: JSONObject): JSONObject? = runCatching {
+        val request = Request.Builder()
+            .url(url)
+            .post(body.toString().toRequestBody(JSON_MEDIA_TYPE))
+            .build()
+        client.newCall(request).execute().use { response ->
+            val responseBody = response.body?.string() ?: return@use null
+            JSONObject(responseBody)
+        }
+    }.getOrNull()
+
+    private fun delete(url: String, body: JSONObject) {
+        runCatching {
+            val request = Request.Builder()
+                .url(url)
+                .delete(body.toString().toRequestBody(JSON_MEDIA_TYPE))
+                .build()
+            client.newCall(request).execute().close()
+        }
+    }
+}

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/ResumePlaybackManager.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/ResumePlaybackManager.kt
@@ -46,7 +46,9 @@ internal class ResumePlaybackManager(
     private val periodicSaveJob = scope.launch {
         while (isActive) {
             delay(SAVE_INTERVAL_MS)
-            if (player.isPlaying) saveWatchedPosition()
+            withContext(Dispatchers.Main) {
+                if (player.isPlaying) saveWatchedPosition()
+            }
         }
     }
 

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -156,6 +156,9 @@ private constructor(
         }
     )
 
+    private val resumePlaybackManager: ResumePlaybackManager? =
+        TPStreamsSDK.userId?.let { ResumePlaybackManager(this, assetId) }
+
     fun retry() {
         if (released) return
         networkDiagnosticsManager.onManualRetry()
@@ -344,6 +347,13 @@ private constructor(
             override fun onPlaybackStateChanged(playbackState: Int) {
                 Log.d("TPStreamsPlayer", "Player state changed: state=$playbackState, playWhenReady=${exoPlayer.playWhenReady}")
                 seekToStartAt()
+                if (playbackState == Player.STATE_READY) {
+                    if (startAt <= 0 && !_isLiveStream) {
+                        resumePlaybackManager?.onPlayerReady()
+                    }
+                } else if (playbackState == Player.STATE_ENDED) {
+                    resumePlaybackManager?.onVideoEnded()
+                }
             }
             
             override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {
@@ -352,7 +362,11 @@ private constructor(
             
             override fun onIsPlayingChanged(isPlaying: Boolean) {
                 Log.d("TPStreamsPlayer", "Is playing changed: $isPlaying")
-                if (isPlaying) networkDiagnosticsManager.onPlaybackRecovered()
+                if (isPlaying) {
+                    networkDiagnosticsManager.onPlaybackRecovered()
+                } else {
+                    resumePlaybackManager?.onPaused()
+                }
             }
             
             override fun onPlayerError(error: PlaybackException) {
@@ -393,6 +407,16 @@ private constructor(
             
             override fun onIsLoadingChanged(isLoading: Boolean) {
                 Log.d("TPStreamsPlayer", "Is loading changed: $isLoading")
+            }
+
+            override fun onPositionDiscontinuity(
+                oldPosition: Player.PositionInfo,
+                newPosition: Player.PositionInfo,
+                discontinuityReason: Int
+            ) {
+                if (discontinuityReason == Player.DISCONTINUITY_REASON_SEEK) {
+                    resumePlaybackManager?.onSeeked()
+                }
             }
         })
 
@@ -668,6 +692,7 @@ private constructor(
     override fun release() {
         debugLog("Surface DETACH (Player Released)")
         debugLog("Player RELEASE - assetId: $assetId")
+        resumePlaybackManager?.onRelease()
         synchronized(TPStreamsPlayer::class.java) {
             activePlayerCount--
             debugLog("Active Player COUNT: $activePlayerCount")

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsSDK.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsSDK.kt
@@ -16,6 +16,13 @@ object TPStreamsSDK {
     internal var authToken: String? = null
         private set
 
+    /**
+     * Logged-in user's ID. Set before creating a [TPStreamsPlayer] to enable resume playback.
+     * When null (default), all resume-related requests are silently skipped.
+     */
+    @JvmStatic
+    var userId: String? = null
+
     internal var orgId: String?
         get() = _orgCode
         private set(value) {

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsSDK.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsSDK.kt
@@ -17,7 +17,8 @@ object TPStreamsSDK {
         private set
 
     /**
-     * Logged-in user's ID. Set before creating a [TPStreamsPlayer] to enable resume playback.
+     * Logged-in user's ID. Must be set before creating a [TPStreamsPlayer] to enable resume
+     * playback; changing it after the player is created has no effect on that player.
      * When null (default), all resume-related requests are silently skipped.
      */
     @JvmStatic


### PR DESCRIPTION
Users who left a video midway had to manually find where they stopped.

The player kept no record of the watch position, so every reopening started from the beginning.

- The position is now saved on pause, on seek, periodically every 2m while watching, and when the player is closed.
- Reopening the same video restores the saved position automatically.
- The saved position is cleared when the video is played to the end.
- The feature is opt-in per user: setting the user id before playback enables it; without it, nothing is saved or restored.