### PR TITLE
fix: Allow continuous playback when live stream ends before VOD is ready

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -484,6 +484,12 @@ private constructor(
                     }
                 }
 
+                if (_isLiveStream && error.errorCode == PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS) {
+                    debugLog("Live stream source returned bad HTTP status — stream likely ended")
+                    _listener?.onError(PlaybackError.LIVE_STREAM_ENDED, "Live stream has ended")
+                    return
+                }
+
                 if (isNetworkError(error)) {
                     networkDiagnosticsManager.handleError(error.toError(), error, cdnHostname, decoderState, mediaUrl)
                     return

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -57,9 +57,11 @@ import com.tpstreams.player.util.DecoderInfoProvider
 import com.tpstreams.player.util.WidevineDrmSessionManagerProvider
 import com.tpstreams.player.util.WidevinePlaybackLevelResolver
 import com.tpstreams.player.data.PlayerDecoderState
+import com.tpstreams.player.util.*
 import io.sentry.Breadcrumb
 import io.sentry.Sentry
 import io.sentry.SentryLevel
+import com.tpstreams.player.util.findHttpResponseCode
 
 
 
@@ -485,9 +487,17 @@ private constructor(
                 }
 
                 if (_isLiveStream && error.errorCode == PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS) {
-                    debugLog("Live stream source returned bad HTTP status — stream likely ended")
-                    _listener?.onError(PlaybackError.LIVE_STREAM_ENDED, "Live stream has ended")
-                    return
+                    val httpResponseCode = error.findHttpResponseCode()
+                    val isAppropriateForLiveStreamEnd = httpResponseCode != null &&
+                        httpResponseCode != HTTP_STATUS_UNAUTHORIZED &&
+                        httpResponseCode != HTTP_STATUS_FORBIDDEN &&
+                        httpResponseCode != HTTP_STATUS_NOT_FOUND &&
+                        httpResponseCode !in HTTP_STATUS_SERVER_ERROR_MIN..HTTP_STATUS_SERVER_ERROR_MAX
+                    if (isAppropriateForLiveStreamEnd) {
+                        debugLog("Live stream source returned bad HTTP status — stream likely ended")
+                        _listener?.onError(PlaybackError.LIVE_STREAM_ENDED, "Live stream has ended")
+                        return
+                    }
                 }
 
                 if (isNetworkError(error)) {

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/api/TPStreamsApiService.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/api/TPStreamsApiService.kt
@@ -41,14 +41,19 @@ class TPStreamsApiService : BaseApiService() {
     private fun parseLiveStreamAssetInfo(json: JSONObject, title: String): AssetInfo {
         val liveStreamObj = json.getJSONObject("live_stream")
         val liveStreamStatus = liveStreamObj.optString("status", "")
+        val transcodeRecordedVideo = liveStreamObj.optBoolean("transcodeRecordedVideo", true)
 
         return when (liveStreamStatus.uppercase(Locale.ROOT)) {
             "NOT STARTED" -> throw LiveStreamNotStartedException("Live stream will begin soon")
             "COMPLETED" -> {
-                // Backend marks the live stream COMPLETED before VOD transcoding finishes.
-                // Keep serving the live proxy until a playable recorded URL exists.
-                createRecordedAssetInfoIfReady(json, title)
-                    ?: createLiveStreamAssetInfo(liveStreamObj, title)
+                val recordedInfo = createRecordedAssetInfoIfReady(json, title)
+                if (!transcodeRecordedVideo && recordedInfo == null) {
+                    createLiveStreamAssetInfo(liveStreamObj, title)
+                } else if (recordedInfo != null) {
+                    recordedInfo
+                } else {
+                    createLiveStreamAssetInfo(liveStreamObj, title)
+                }
             }
 
             else -> {

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/api/TPStreamsApiService.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/api/TPStreamsApiService.kt
@@ -45,49 +45,60 @@ class TPStreamsApiService : BaseApiService() {
         return when (liveStreamStatus.uppercase(Locale.ROOT)) {
             "NOT STARTED" -> throw LiveStreamNotStartedException("Live stream will begin soon")
             "COMPLETED" -> {
-                if (json.has("video") && !json.isNull("video")) {
-                    val videoObj = json.getJSONObject("video")
-                    val videoStatus = videoObj.optString("status", "")
-
-                    if (videoStatus.equals("Completed", ignoreCase = true)) {
-                        val enableDrm = videoObj.optBoolean("enable_drm", false)
-                        val isAes = videoObj.optString("content_protection_type").equals("aes", ignoreCase = true)
-                        AssetInfo(
-                            mediaUrl = getVideoPlaybackUrl(videoObj, enableDrm),
-                            enableDrm = enableDrm,
-                            thumbnailUrl = getThumbnail(videoObj),
-                            videoObj = videoObj,
-                            isLiveStream = false,
-                            durationSeconds = videoObj.optDouble("duration", 0.0),
-                            title = title,
-                            isAes = isAes
-                        )
-                    } else {
-                        throw LiveStreamEndedException("Live stream has ended")
-                    }
-                } else {
-                    throw LiveStreamEndedException("Live stream has ended")
-                }
+                // Backend marks the live stream COMPLETED before VOD transcoding finishes.
+                // Keep serving the live proxy until a playable recorded URL exists.
+                createRecordedAssetInfoIfReady(json, title)
+                    ?: createLiveStreamAssetInfo(liveStreamObj, title)
             }
 
             else -> {
-                val enableDrm = liveStreamObj.optBoolean("enable_drm", false)
-                val mediaUrl = if (enableDrm) {
-                    liveStreamObj.optString("dash_url")
-                } else {
-                    liveStreamObj.optString("hls_url")
-                }
-                AssetInfo(
-                    mediaUrl = mediaUrl,
-                    enableDrm = enableDrm,
-                    thumbnailUrl = "",
-                    videoObj = null,
-                    isLiveStream = true,
-                    durationSeconds = liveStreamObj.optDouble("duration", 0.0),
-                    title = title
-                )
+                createLiveStreamAssetInfo(liveStreamObj, title)
             }
         }
+    }
+
+    private fun createRecordedAssetInfoIfReady(json: JSONObject, title: String): AssetInfo? {
+        if (!json.has("video") || json.isNull("video")) return null
+
+        val videoObj = json.getJSONObject("video")
+        if (!videoObj.optString("status").equals("Completed", ignoreCase = true)) return null
+
+        val enableDrm = videoObj.optBoolean("enable_drm", false)
+        val mediaUrl = getVideoPlaybackUrl(videoObj, enableDrm)
+        if (mediaUrl.isEmpty()) return null
+
+        val isAes = videoObj.optString("content_protection_type").equals("aes", ignoreCase = true)
+        return AssetInfo(
+            mediaUrl = mediaUrl,
+            enableDrm = enableDrm,
+            thumbnailUrl = getThumbnail(videoObj),
+            videoObj = videoObj,
+            isLiveStream = false,
+            durationSeconds = videoObj.optDouble("duration", 0.0),
+            title = title,
+            isAes = isAes
+        )
+    }
+
+    private fun createLiveStreamAssetInfo(liveStreamObj: JSONObject, title: String): AssetInfo {
+        val enableDrm = liveStreamObj.optBoolean("enable_drm", false)
+        val mediaUrl = if (enableDrm) {
+            liveStreamObj.optString("dash_url")
+        } else {
+            liveStreamObj.optString("hls_url")
+        }
+        if (mediaUrl.isEmpty()) {
+            throw LiveStreamEndedException("Live stream has ended")
+        }
+        return AssetInfo(
+            mediaUrl = mediaUrl,
+            enableDrm = enableDrm,
+            thumbnailUrl = "",
+            videoObj = null,
+            isLiveStream = true,
+            durationSeconds = liveStreamObj.optDouble("duration", 0.0),
+            title = title
+        )
     }
 
     private fun parseVideoAssetInfo(json: JSONObject, title: String): AssetInfo {

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/api/TestPressApiService.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/api/TestPressApiService.kt
@@ -60,8 +60,12 @@ class TestPressApiService : BaseApiService() {
             }
 
             else -> {
+                val mediaUrl = liveStreamObj.optString("stream_url", "")
+                if (mediaUrl.isEmpty()) {
+                    throw LiveStreamEndedException(noticeMessage)
+                }
                 AssetInfo(
-                    mediaUrl = liveStreamObj.optString("stream_url", ""),
+                    mediaUrl = mediaUrl,
                     enableDrm = false,
                     thumbnailUrl = "",
                     videoObj = null,


### PR DESCRIPTION
* Users were seeing a black screen after a live stream ended because the SDK treated the `COMPLETED` status as an error when the video file was not yet available.
* This happened because backend status changes to `COMPLETED` before the recording finishes transcoding, creating a gap where the VOD URL is unavailable.
* Updated `parseLiveStreamAssetInfo` to fall back to the live proxy's `hls_url` / `dash_url` during this gap, allowing users to continue playback seamlessly until the optimized VOD URL becomes available.