### PR TITLE
fix: fallback to L3 when decoder initialization fails

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -452,7 +452,7 @@ private constructor(
                 // --- DRM fallback to L3 ---
                 // Covers all DRM errors worth retrying at L3:
                 //   PROVISIONING_FAILED, LICENSE_ACQUISITION_FAILED, SYSTEM_ERROR,
-                //   DISALLOWED_OPERATION, MediaCodec.CryptoException
+                //   DISALLOWED_OPERATION, DECODER_INIT_FAILED, MediaCodec.CryptoException
                 // DRM_LICENSE_EXPIRED is excluded — it has its own renewal path above.
                 if (WidevinePlaybackLevelResolver.isFallbackAllowed() &&
                     isDrmContent &&

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/WidevinePlaybackLevelResolver.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/WidevinePlaybackLevelResolver.kt
@@ -160,9 +160,7 @@ internal object WidevinePlaybackLevelResolver {
                 PlaybackException.ERROR_CODE_DRM_LICENSE_ACQUISITION_FAILED,
                 PlaybackException.ERROR_CODE_DRM_SYSTEM_ERROR,
                 PlaybackException.ERROR_CODE_DRM_DISALLOWED_OPERATION,
-                PlaybackException.ERROR_CODE_DECODER_INIT_FAILED,
-                PlaybackException.ERROR_CODE_DECODING_FAILED,
-                PlaybackException.ERROR_CODE_DECODING_RESOURCES_RECLAIMED -> true
+                PlaybackException.ERROR_CODE_DECODER_INIT_FAILED -> true
                 else -> false
             }
         ) {

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/util/WidevinePlaybackLevelResolver.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/util/WidevinePlaybackLevelResolver.kt
@@ -159,7 +159,10 @@ internal object WidevinePlaybackLevelResolver {
                 PlaybackException.ERROR_CODE_DRM_DEVICE_REVOKED,
                 PlaybackException.ERROR_CODE_DRM_LICENSE_ACQUISITION_FAILED,
                 PlaybackException.ERROR_CODE_DRM_SYSTEM_ERROR,
-                PlaybackException.ERROR_CODE_DRM_DISALLOWED_OPERATION -> true
+                PlaybackException.ERROR_CODE_DRM_DISALLOWED_OPERATION,
+                PlaybackException.ERROR_CODE_DECODER_INIT_FAILED,
+                PlaybackException.ERROR_CODE_DECODING_FAILED,
+                PlaybackException.ERROR_CODE_DECODING_RESOURCES_RECLAIMED -> true
                 else -> false
             }
         ) {


### PR DESCRIPTION
* Playback could fail when the device’s hardware decoder could not be initialized, preventing affected users from watching the video.
* This is resolved by falling back to L3 when decoder initialization fails, allowing playback to continue without requiring the user to retry manually.
