### PR TITLE
Wire viewer-count presence heartbeat/leave into the player

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ androidx-media3-exoplayer-hls = { module = "androidx.media3:media3-exoplayer-hls
 androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "media3" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
 sentry-android = { module = "io.sentry:sentry-android", version.ref = "sentry" }
 
 [plugins]

--- a/tpstreams-android-player/build.gradle.kts
+++ b/tpstreams-android-player/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
     api(libs.sentry.android)
 
     testImplementation(libs.junit)
+    testImplementation(libs.okhttp.mockwebserver)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayer.kt
@@ -23,6 +23,10 @@ import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.json.JSONObject
+import com.tpstreams.player.presence.HandlerPresenceScheduler
+import com.tpstreams.player.presence.PresenceConfig
+import com.tpstreams.player.presence.PresenceHeartbeatManager
+import com.tpstreams.player.presence.PresenceViewerIdStore
 import androidx.media3.common.Format
 import android.net.Uri
 import androidx.media3.common.MimeTypes
@@ -101,6 +105,20 @@ private constructor(
          * probes complete. The UI can use this to show a "Diagnosing…" state.
          */
         fun onNetworkDiagnosticsStarted() {}
+        /**
+         * Called on a 401 from the presence heartbeat loop — an expired token and a
+         * device-binding mismatch look identical from here, and both are resolved the
+         * same way: fetch a fresh playback config and call [callback] with its presence
+         * token, or with an empty string if none could be obtained. Mirrors the shape of
+         * [onAccessTokenExpired].
+         *
+         * Default no-op: presence is still rollout-gated to a handful of organizations,
+         * and a required override would break every existing integrator for a feature
+         * almost none of them have enabled. An app that doesn't override this simply
+         * never has its heartbeat loop resume after a 401 — it just quietly stops, the
+         * same as if presence were disabled.
+         */
+        fun onPresenceTokenExpired(videoId: String, callback: (String) -> Unit) {}
     }
 
     private var isPrepared = false
@@ -147,6 +165,14 @@ private constructor(
     @Volatile
     private var decoderState = PlayerDecoderState()
     internal fun getDecoderState(): PlayerDecoderState = decoderState
+
+    // Set from AssetInfo.presence in preparePlayer; read fresh on every
+    // startPresenceHeartbeat() call rather than cached at construction, so a
+    // reload that picks up a renewed token is used without any extra plumbing.
+    @Volatile
+    private var presenceConfig: PresenceConfig? = null
+    private var presenceHeartbeatManager: PresenceHeartbeatManager? = null
+    private val presenceViewerIdStore by lazy { PresenceViewerIdStore(context) }
 
     private val networkDiagnosticsManager = NetworkDiagnosticsManager(
         playerScope = playerScope,
@@ -401,8 +427,10 @@ private constructor(
                 Log.d("TPStreamsPlayer", "Is playing changed: $isPlaying")
                 if (isPlaying) {
                     networkDiagnosticsManager.onPlaybackRecovered()
+                    startPresenceHeartbeat()
                 } else {
                     resumePlaybackManager?.onPaused()
+                    stopPresenceHeartbeat()
                 }
             }
             
@@ -493,6 +521,10 @@ private constructor(
         CoroutineScope(Dispatchers.IO).launch {
             if (playFromDownload(assetId)) return@launch
 
+            // Only meaningful for the TPStreams provider; TPStreamsApiService is
+            // what actually uses it, TestPressApiService ignores it.
+            val viewerId = presenceViewerIdStore.getOrCreate()
+
             AssetRepository.fetchAssetInfo(assetId, accessToken, object : AssetRepository.AssetCallback {
                 override fun onSuccess(assetInfo: AssetInfo) {
                     val safeHost = try { Uri.parse(assetInfo.mediaUrl).host } catch (_: Exception) { "unknown" }
@@ -533,13 +565,14 @@ private constructor(
                         }
                     }
                 }
-            }, context = context)
+            }, context = context, viewerId = viewerId)
         }
     }
 
     @OptIn(UnstableApi::class)
     private fun preparePlayer(assetInfo: AssetInfo, assetId: String, accessToken: String) {
         val orgId = TPStreamsSDK.requireOrgId()
+        presenceConfig = assetInfo.presence
         cdnHostname = try {
             Uri.parse(assetInfo.mediaUrl).host?.takeIf { it.isNotBlank() }
         } catch (_: Exception) { null }
@@ -735,6 +768,7 @@ private constructor(
     override fun release() {
         debugLog("Surface DETACH (Player Released)")
         debugLog("Player RELEASE - assetId: $assetId")
+        stopPresenceHeartbeat()
         resumePlaybackManager?.onRelease()
         synchronized(TPStreamsPlayer::class.java) {
             activePlayerCount--
@@ -969,6 +1003,25 @@ private constructor(
                 }
             }
         }
+    }
+
+    private fun startPresenceHeartbeat() {
+        val presence = presenceConfig ?: return
+        if (presenceHeartbeatManager == null) {
+            presenceHeartbeatManager = PresenceHeartbeatManager(
+                httpClient = client,
+                viewerId = presenceViewerIdStore.getOrCreate(),
+                scheduler = HandlerPresenceScheduler(),
+                onTokenExpired = { callback ->
+                    listener?.onPresenceTokenExpired(assetId, callback) ?: callback("")
+                },
+            )
+        }
+        presenceHeartbeatManager?.start(presence.baseUrl, presence.token)
+    }
+
+    private fun stopPresenceHeartbeat() {
+        presenceHeartbeatManager?.stop()
     }
 
     fun getNewToken(assetId: String, callback: (String) -> Unit) {

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/data/AssetRepository.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/data/AssetRepository.kt
@@ -34,13 +34,14 @@ object AssetRepository {
         assetId: String,
         accessToken: String,
         callback: AssetCallback,
-        context: Context? = null
+        context: Context? = null,
+        viewerId: String? = null
     ) {
         TPStreamsSDK.requireOrgId()
         val apiService = TPStreamsSDK.apiService
         CoroutineScope(Dispatchers.IO).launch {
             try {
-                val assetApiUrl = apiService.assetInfoUrl(orgId, assetId, accessToken)
+                val assetApiUrl = apiService.assetInfoUrl(orgId, assetId, accessToken, viewerId)
                 val requestBuilder = Request.Builder().url(assetApiUrl)
                 TPStreamsSDK.getAuthHeaders().forEach { (name, value) ->
                     requestBuilder.addHeader(name, value)
@@ -67,7 +68,7 @@ object AssetRepository {
                     callback.onSuccess(assetInfo)
                 }
             } catch (e: Exception) {
-                val url = runCatching { apiService.assetInfoUrl(orgId, assetId, accessToken) }.getOrNull() ?: ""
+                val url = runCatching { apiService.assetInfoUrl(orgId, assetId, accessToken, viewerId) }.getOrNull() ?: ""
                 handleException(assetId, e, url, callback, context)
             }
         }
@@ -77,9 +78,10 @@ object AssetRepository {
         assetId: String,
         accessToken: String,
         callback: AssetCallback,
-        context: Context? = null
+        context: Context? = null,
+        viewerId: String? = null
     ) {
-        fetchAssetInfo(TPStreamsSDK.requireOrgId(), assetId, accessToken, callback, context)
+        fetchAssetInfo(TPStreamsSDK.requireOrgId(), assetId, accessToken, callback, context, viewerId)
     }
 
     private fun handleApiError(assetId: String, code: Int, url: String, callback: AssetCallback, context: Context? = null) {

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/api/BaseApiService.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/api/BaseApiService.kt
@@ -4,7 +4,12 @@ import com.tpstreams.player.data.network.model.AssetInfo
 import org.json.JSONObject
 
 abstract class BaseApiService {
-    abstract fun assetInfoUrl(orgId: String, assetId: String, accessToken: String): String
+    // viewerId is only ever meaningful for TPStreamsApiService: it lets the
+    // response carry a presence token bound to this device (see
+    // PresenceViewerIdStore). TestPressApiService has no presence/live-viewer-
+    // count support, so it accepts and ignores the parameter rather than
+    // threading it into a URL format that has nothing to do with it.
+    abstract fun assetInfoUrl(orgId: String, assetId: String, accessToken: String, viewerId: String? = null): String
 
     abstract fun drmLicenseUrl(
         orgId: String,

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/api/TPStreamsApiService.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/api/TPStreamsApiService.kt
@@ -3,13 +3,20 @@ package com.tpstreams.player.data.network.api
 import com.tpstreams.player.constants.LiveStreamEndedException
 import com.tpstreams.player.constants.LiveStreamNotStartedException
 import com.tpstreams.player.data.network.model.AssetInfo
+import com.tpstreams.player.presence.PresenceConfig
 import org.json.JSONObject
 import java.util.Locale
 
 class TPStreamsApiService : BaseApiService() {
-    override fun assetInfoUrl(orgId: String, assetId: String, accessToken: String): String {
+    override fun assetInfoUrl(orgId: String, assetId: String, accessToken: String, viewerId: String?): String {
         val baseUrl = "https://app.tpstreams.com/api/v1/$orgId/assets/$assetId/"
-        return if (accessToken.isNotBlank()) "$baseUrl?access_token=$accessToken" else baseUrl
+        val withToken = if (accessToken.isNotBlank()) "$baseUrl?access_token=$accessToken" else baseUrl
+        if (viewerId.isNullOrEmpty()) return withToken
+        // Without this the server mints a fresh anonymous id per request, and
+        // the presence token it hands back could never pass device binding at
+        // all — see PresenceViewerIdStore.
+        val separator = if (withToken.contains("?")) "&" else "?"
+        return "$withToken${separator}viewer_id=$viewerId"
     }
 
     override fun drmLicenseUrl(
@@ -84,7 +91,8 @@ class TPStreamsApiService : BaseApiService() {
                     videoObj = null,
                     isLiveStream = true,
                     durationSeconds = liveStreamObj.optDouble("duration", 0.0),
-                    title = title
+                    title = title,
+                    presence = parsePresence(liveStreamObj.optJSONObject("presence"))
                 )
             }
         }
@@ -130,5 +138,17 @@ class TPStreamsApiService : BaseApiService() {
     private fun getThumbnail(videoObj: JSONObject): String {
         return videoObj.optString("preview_thumbnail_url")
             .ifEmpty { videoObj.optJSONArray("thumbnails")?.optString(0) ?: "" }
+    }
+
+    // A malformed or absent presence payload is treated as no presence at
+    // all, rather than propagating a half-populated config further —
+    // presence is a bolt-on feature that must never be able to break asset
+    // parsing or playback.
+    private fun parsePresence(presenceObj: JSONObject?): PresenceConfig? {
+        if (presenceObj == null) return null
+        val token = presenceObj.optString("token")
+        val baseUrl = presenceObj.optString("base_url")
+        if (token.isBlank() || baseUrl.isBlank()) return null
+        return PresenceConfig(token = token, baseUrl = baseUrl)
     }
 }

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/api/TestPressApiService.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/api/TestPressApiService.kt
@@ -7,7 +7,9 @@ import org.json.JSONObject
 import java.util.Locale
 
 class TestPressApiService : BaseApiService() {
-    override fun assetInfoUrl(orgId: String, assetId: String, accessToken: String): String {
+    // viewerId is accepted but ignored: this provider has no presence/live-
+    // viewer-count support to bind a device to.
+    override fun assetInfoUrl(orgId: String, assetId: String, accessToken: String, viewerId: String?): String {
         val baseUrl = "https://$orgId.testpress.in/api/v2.5/video_info/$assetId/?v=2"
         return if (accessToken.isNotBlank()) "$baseUrl&access_token=$accessToken" else baseUrl
     }

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/model/AssetInfo.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/data/network/model/AssetInfo.kt
@@ -1,5 +1,6 @@
 package com.tpstreams.player.data.network.model
 
+import com.tpstreams.player.presence.PresenceConfig
 import org.json.JSONObject
 
 /**
@@ -14,6 +15,8 @@ import org.json.JSONObject
  * @property isLiveStream Whether this asset is an active live stream (not recorded)
  * @property durationSeconds Duration of the video in seconds
  * @property isAes Whether the stream uses AES content protection
+ * @property presence Live-viewer-count config for this stream, when the organization has opted
+ *   into that rollout — null otherwise, including for non-live-stream assets.
  */
 data class AssetInfo(
     val title: String,
@@ -23,5 +26,6 @@ data class AssetInfo(
     val videoObj: JSONObject?,
     val isLiveStream: Boolean = false,
     val durationSeconds: Double = 0.0,
-    val isAes: Boolean = false
+    val isAes: Boolean = false,
+    val presence: PresenceConfig? = null
 )

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/presence/PresenceConfig.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/presence/PresenceConfig.kt
@@ -1,0 +1,9 @@
+package com.tpstreams.player.presence
+
+// Nothing downstream needs the hashed vid the server also mints alongside
+// this — only the raw device id (PresenceViewerIdStore) that produced it,
+// which the app already has, matters for resending on heartbeat/leave.
+data class PresenceConfig(
+    val token: String,
+    val baseUrl: String
+)

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/presence/PresenceHeartbeatManager.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/presence/PresenceHeartbeatManager.kt
@@ -1,0 +1,199 @@
+package com.tpstreams.player.presence
+
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import org.json.JSONObject
+import java.io.IOException
+import kotlin.random.Random
+
+// Mirrors the web presence-client's heartbeat loop (see player.js's
+// PresenceClient) and the iOS SDK's PresenceHeartbeatManager, so all three
+// behave identically from the server's point of view. Kept entirely internal
+// to the player: an app never starts or stops this directly, only
+// TPStreamsPlayer.Listener.onPresenceTokenExpired reaches outside this class,
+// when a fresh token is needed.
+internal class PresenceHeartbeatManager(
+    private val httpClient: OkHttpClient,
+    private val viewerId: String,
+    private val scheduler: PresenceScheduler,
+    // Called on a 401 with a callback that must be invoked with a fresh token,
+    // or with an empty string if none could be obtained. Wraps
+    // TPStreamsPlayer.Listener.onPresenceTokenExpired, which is a no-op
+    // default — an app that hasn't implemented it simply never calls this
+    // back, and the loop quietly stops rather than erroring.
+    private val onTokenExpired: (callback: (String) -> Unit) -> Unit,
+    private val onError: ((Throwable) -> Unit)? = null,
+    private val fallbackIntervalMillis: Long = DEFAULT_FALLBACK_INTERVAL_MILLIS,
+) {
+    @Volatile private var token: String = ""
+    @Volatile private var baseUrl: String = ""
+    @Volatile private var active = false
+    @Volatile private var unauthorizedStreak = 0
+    private var scheduled: PresenceScheduler.Cancellable? = null
+
+    // Call this only while playback is actually active. Safe to call more
+    // than once; a call while already active is a no-op.
+    @Synchronized
+    fun start(baseUrl: String, token: String) {
+        if (active || baseUrl.isEmpty() || token.isEmpty()) return
+        this.baseUrl = baseUrl
+        this.token = token
+        this.unauthorizedStreak = 0
+        active = true
+        // Spreads the first beat across the interval instead of firing it the
+        // moment playback starts. A scheduled class means many viewers
+        // pressing play within the same few seconds, and without this they
+        // would then beat in lockstep for the whole session — a request spike
+        // every interval rather than steady load.
+        scheduleNextBeat((Random.nextDouble() * fallbackIntervalMillis).toLong())
+    }
+
+    // Sends a final leave beacon and stops the loop. Safe to call more than
+    // once or without a matching start().
+    @Synchronized
+    fun stop() {
+        if (!active) return
+        active = false
+        scheduled?.cancel()
+        scheduled = null
+        sendLeaveBeacon()
+    }
+
+    @Synchronized
+    private fun scheduleNextBeat(delayMillis: Long) {
+        if (!active) return
+        scheduled = scheduler.schedule(delayMillis) { beat() }
+    }
+
+    private fun beat() {
+        val currentToken: String
+        val currentBaseUrl: String
+        synchronized(this) {
+            if (!active) return
+            currentToken = token
+            currentBaseUrl = baseUrl
+        }
+
+        val body = JSONObject().put("viewer_id", viewerId).toString()
+        val request = Request.Builder()
+            .url("$currentBaseUrl/presence/v1/heartbeat")
+            .addHeader("Authorization", "Bearer $currentToken")
+            // Resent on every call, not just once when requesting playback: the
+            // server hashes it and checks it still matches the vid baked into
+            // the token, so a token copied to another device gets rejected.
+            .post(body.toRequestBody(JSON_MEDIA_TYPE))
+            .build()
+
+        httpClient.newCall(request).enqueue(object : Callback {
+            override fun onFailure(call: Call, e: IOException) {
+                // Network hiccup: keep the loop alive on the fallback cadence
+                // rather than letting this bring playback down with it.
+                onError?.invoke(e)
+                scheduleNextBeat(fallbackIntervalMillis)
+            }
+
+            override fun onResponse(call: Call, response: Response) {
+                response.use { handleHeartbeatResponse(it) }
+            }
+        })
+    }
+
+    private fun handleHeartbeatResponse(response: Response) {
+        when {
+            response.code == 401 -> recoverFromUnauthorized()
+            response.code == 429 -> {
+                unauthorizedStreak = 0
+                val retryAfterSeconds = response.header("Retry-After")?.toLongOrNull()
+                scheduleNextBeat((retryAfterSeconds ?: (fallbackIntervalMillis / 1000)) * 1000)
+            }
+            response.isSuccessful -> {
+                unauthorizedStreak = 0
+                val nextHeartbeatIn = parseNextHeartbeatIn(response)
+                scheduleNextBeat((nextHeartbeatIn ?: (fallbackIntervalMillis / 1000)) * 1000)
+            }
+            else -> {
+                onError?.invoke(IOException("Unexpected heartbeat response: ${response.code}"))
+                scheduleNextBeat(fallbackIntervalMillis)
+            }
+        }
+    }
+
+    private fun parseNextHeartbeatIn(response: Response): Long? {
+        return try {
+            val body = response.body?.string() ?: return null
+            val nextHeartbeatIn = JSONObject(body).optLong("next_heartbeat_in", -1L)
+            if (nextHeartbeatIn > 0) nextHeartbeatIn else null
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    // A 401 here could mean either an expired token or a device-binding
+    // mismatch — there's no need to tell them apart, both are resolved by
+    // asking the integrator for a fresh playback config and resuming with its
+    // token, exactly like the web SDK's recoverFromUnauthorized.
+    private fun recoverFromUnauthorized() {
+        unauthorizedStreak += 1
+        onTokenExpired { newToken ->
+            if (newToken.isNotEmpty()) {
+                applyRefreshedToken(newToken)
+            } else {
+                backOffAfterFailedRefresh()
+            }
+        }
+    }
+
+    @Synchronized
+    private fun applyRefreshedToken(newToken: String) {
+        if (!active) return
+        token = newToken
+        unauthorizedStreak = 0
+        scheduleNextBeat(fallbackIntervalMillis)
+    }
+
+    @Synchronized
+    private fun backOffAfterFailedRefresh() {
+        if (!active) return
+        // Backs off further each consecutive failure — capped, not abandoned:
+        // an integrator's own backend can be down for a while and recover, and
+        // this loop has no playback-affecting reason to ever give up on it.
+        val multiplier = minOf(unauthorizedStreak, MAX_BACKOFF_MULTIPLIER)
+        scheduleNextBeat(fallbackIntervalMillis * multiplier)
+    }
+
+    private fun sendLeaveBeacon() {
+        // No Android equivalent to navigator.sendBeacon: this is a best-effort,
+        // fire-and-forget POST that never blocks player teardown on a response.
+        val body = JSONObject()
+            .put("presence_token", token)
+            .put("viewer_id", viewerId)
+            .toString()
+        val request = Request.Builder()
+            .url("$baseUrl/presence/v1/leave")
+            .post(body.toRequestBody(JSON_MEDIA_TYPE))
+            .build()
+        httpClient.newCall(request).enqueue(object : Callback {
+            override fun onFailure(call: Call, e: IOException) {
+                onError?.invoke(e)
+            }
+
+            override fun onResponse(call: Call, response: Response) {
+                response.close()
+            }
+        })
+    }
+
+    companion object {
+        private const val DEFAULT_FALLBACK_INTERVAL_MILLIS = 15_000L
+        // Repeated 401s back off by a growing multiple of the fallback
+        // interval, capped so a long-broken refresh callback still gets
+        // retried every couple of minutes instead of trailing off to nothing.
+        private const val MAX_BACKOFF_MULTIPLIER = 8
+        private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
+    }
+}

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/presence/PresenceScheduler.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/presence/PresenceScheduler.kt
@@ -1,0 +1,29 @@
+package com.tpstreams.player.presence
+
+import android.os.Handler
+import android.os.Looper
+
+// Abstracts the heartbeat loop's delayed scheduling away from a real Android
+// Handler/Looper so PresenceHeartbeatManager can be unit tested with a fake
+// that fires immediately, without depending on Robolectric.
+internal interface PresenceScheduler {
+    fun schedule(delayMillis: Long, action: () -> Unit): Cancellable
+
+    interface Cancellable {
+        fun cancel()
+    }
+}
+
+internal class HandlerPresenceScheduler(
+    private val handler: Handler = Handler(Looper.getMainLooper())
+) : PresenceScheduler {
+    override fun schedule(delayMillis: Long, action: () -> Unit): PresenceScheduler.Cancellable {
+        val runnable = Runnable(action)
+        handler.postDelayed(runnable, delayMillis)
+        return object : PresenceScheduler.Cancellable {
+            override fun cancel() {
+                handler.removeCallbacks(runnable)
+            }
+        }
+    }
+}

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/presence/PresenceViewerIdStore.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/presence/PresenceViewerIdStore.kt
@@ -1,0 +1,46 @@
+package com.tpstreams.player.presence
+
+import android.content.Context
+import java.util.UUID
+
+internal interface PersistentKeyValueStore {
+    fun getString(key: String): String?
+    fun putString(key: String, value: String)
+}
+
+internal class SharedPreferencesKeyValueStore(context: Context) : PersistentKeyValueStore {
+    private val preferences = context.applicationContext
+        .getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+
+    override fun getString(key: String): String? = preferences.getString(key, null)
+
+    override fun putString(key: String, value: String) {
+        preferences.edit().putString(key, value).apply()
+    }
+
+    companion object {
+        private const val PREFERENCES_NAME = "tpstreams_presence"
+    }
+}
+
+// Generated once and persisted, so the same value can be forwarded as the
+// viewer_id query param when requesting playback and resent on every
+// heartbeat/leave call after — same purpose as the web SDK's
+// getOrCreatePersistentViewerId(), backed by SharedPreferences so it survives
+// app restarts instead of localStorage.
+internal class PresenceViewerIdStore(private val store: PersistentKeyValueStore) {
+    constructor(context: Context) : this(SharedPreferencesKeyValueStore(context))
+
+    fun getOrCreate(): String {
+        val existing = store.getString(KEY_VIEWER_ID)
+        if (existing != null) return existing
+
+        val generated = UUID.randomUUID().toString()
+        store.putString(KEY_VIEWER_ID, generated)
+        return generated
+    }
+
+    companion object {
+        private const val KEY_VIEWER_ID = "viewer_id"
+    }
+}

--- a/tpstreams-android-player/src/test/java/com/tpstreams/player/data/network/api/ApiServiceTest.kt
+++ b/tpstreams-android-player/src/test/java/com/tpstreams/player/data/network/api/ApiServiceTest.kt
@@ -1,6 +1,8 @@
 package com.tpstreams.player.data.network.api
 
+import org.json.JSONObject
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class ApiServiceTest {
@@ -20,6 +22,32 @@ class ApiServiceTest {
     }
 
     @Test
+    fun `tpstreams api appends viewer_id when one is supplied`() {
+        assertEquals(
+            "https://app.tpstreams.com/api/v1/org/assets/asset/?access_token=token&viewer_id=device-abc",
+            tpStreamsApi.assetInfoUrl("org", "asset", "token", viewerId = "device-abc")
+        )
+    }
+
+    @Test
+    fun `tpstreams api omits viewer_id when none is supplied`() {
+        assertEquals(
+            "https://app.tpstreams.com/api/v1/org/assets/asset/?access_token=token",
+            tpStreamsApi.assetInfoUrl("org", "asset", "token", viewerId = null)
+        )
+    }
+
+    // The legacy TestPress provider has no presence/live-viewer-count support,
+    // so a viewer id has nothing to bind there and must not leak into the URL.
+    @Test
+    fun `testpress api ignores viewer_id even when one is supplied`() {
+        assertEquals(
+            "https://demo.testpress.in/api/v2.5/video_info/asset/?v=2&access_token=token",
+            testPressApi.assetInfoUrl("demo", "asset", "token", viewerId = "device-abc")
+        )
+    }
+
+    @Test
     fun `testpress api builds urls`() {
         assertEquals(
             "https://demo.testpress.in/api/v2.5/video_info/asset/?v=2&access_token=token",
@@ -29,5 +57,54 @@ class ApiServiceTest {
             "https://demo.testpress.in/api/v2.5/drm_license_key/asset/?access_token=token",
             testPressApi.drmLicenseUrl("demo", "asset", "token")
         )
+    }
+
+    private fun liveStreamJson(presenceJson: String = ""): JSONObject {
+        return JSONObject(
+            """
+            {
+                "title": "Live Class",
+                "type": "livestream",
+                "live_stream": {
+                    "status": "Streaming",
+                    "hls_url": "https://example.com/live.m3u8",
+                    "dash_url": "https://example.com/live.mpd",
+                    "enable_drm": false
+                    $presenceJson
+                }
+            }
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `tpstreams api parses a present presence config on a live stream`() {
+        val assetInfo = tpStreamsApi.parseAsset(
+            liveStreamJson(""", "presence": {"token": "presence-token-abc", "vid": "irrelevant", "base_url": "https://presence.tpstreams.test"}""")
+        )
+
+        assertEquals("presence-token-abc", assetInfo.presence?.token)
+        assertEquals("https://presence.tpstreams.test", assetInfo.presence?.baseUrl)
+    }
+
+    @Test
+    fun `tpstreams api parses an absent presence key as no presence`() {
+        // What every organization not yet opted into the rollout actually
+        // gets back — must parse cleanly rather than error.
+        val assetInfo = tpStreamsApi.parseAsset(liveStreamJson())
+
+        assertNull(assetInfo.presence)
+    }
+
+    // A malformed presence (missing token or base_url) is treated the same as
+    // no presence at all, rather than letting a half-populated config reach
+    // the heartbeat manager.
+    @Test
+    fun `tpstreams api parses a presence config missing its token as no presence`() {
+        val assetInfo = tpStreamsApi.parseAsset(
+            liveStreamJson(""", "presence": {"base_url": "https://presence.tpstreams.test"}""")
+        )
+
+        assertNull(assetInfo.presence)
     }
 }

--- a/tpstreams-android-player/src/test/java/com/tpstreams/player/presence/PresenceHeartbeatManagerTest.kt
+++ b/tpstreams-android-player/src/test/java/com/tpstreams/player/presence/PresenceHeartbeatManagerTest.kt
@@ -1,0 +1,288 @@
+package com.tpstreams.player.presence
+
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+private const val VIEWER_ID = "device-abc-123"
+
+// Records every scheduled beat instead of running it, so the test controls
+// exactly when each one fires — the real network round-trip against
+// MockWebServer still happens on OkHttp's own dispatcher thread, which is
+// what makes a blocking queue the right synchronization primitive here rather
+// than a plain field.
+private class RecordingPresenceScheduler : PresenceScheduler {
+    data class ScheduledCall(val delayMillis: Long, val action: () -> Unit)
+
+    private val scheduledCalls = LinkedBlockingQueue<ScheduledCall>()
+    val cancelledCount = AtomicInteger(0)
+
+    override fun schedule(delayMillis: Long, action: () -> Unit): PresenceScheduler.Cancellable {
+        scheduledCalls.put(ScheduledCall(delayMillis, action))
+        return object : PresenceScheduler.Cancellable {
+            override fun cancel() {
+                cancelledCount.incrementAndGet()
+            }
+        }
+    }
+
+    fun awaitNextSchedule(): ScheduledCall {
+        return scheduledCalls.poll(5, TimeUnit.SECONDS)
+            ?: throw AssertionError("No beat was scheduled within the timeout")
+    }
+
+    fun assertNothingScheduledWithin(millis: Long) {
+        val call = scheduledCalls.poll(millis, TimeUnit.MILLISECONDS)
+        assertNull("expected no further beat to be scheduled, but one was", call)
+    }
+}
+
+class PresenceHeartbeatManagerTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var httpClient: OkHttpClient
+    private lateinit var scheduler: RecordingPresenceScheduler
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        httpClient = OkHttpClient()
+        scheduler = RecordingPresenceScheduler()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    private fun buildManager(
+        onTokenExpired: (callback: (String) -> Unit) -> Unit = { callback -> callback("") },
+        onError: ((Throwable) -> Unit)? = null,
+    ): PresenceHeartbeatManager {
+        return PresenceHeartbeatManager(
+            httpClient = httpClient,
+            viewerId = VIEWER_ID,
+            scheduler = scheduler,
+            onTokenExpired = onTokenExpired,
+            onError = onError,
+        )
+    }
+
+    private fun heartbeatOkResponse(nextHeartbeatIn: Int = 15) = MockResponse()
+        .setResponseCode(200)
+        .setBody("""{"ok":true,"next_heartbeat_in":$nextHeartbeatIn}""")
+
+    private fun baseUrl() = server.url("/").toString().trimEnd('/')
+
+    @Test
+    fun `sends the first heartbeat with the bearer token and the persisted viewer id`() {
+        server.enqueue(heartbeatOkResponse())
+        val manager = buildManager()
+
+        manager.start(baseUrl(), "token-1")
+        scheduler.awaitNextSchedule().action()
+
+        val request = server.takeRequest(5, TimeUnit.SECONDS)!!
+        assertEquals("POST", request.method)
+        assertEquals("/presence/v1/heartbeat", request.path)
+        assertEquals("Bearer token-1", request.getHeader("Authorization"))
+        assertEquals(VIEWER_ID, JSONObject(request.body.readUtf8()).getString("viewer_id"))
+    }
+
+    @Test
+    fun `resends the same viewer id on the next heartbeat, not just the first`() {
+        server.enqueue(heartbeatOkResponse(nextHeartbeatIn = 15))
+        server.enqueue(heartbeatOkResponse(nextHeartbeatIn = 15))
+        val manager = buildManager()
+
+        manager.start(baseUrl(), "token-1")
+        scheduler.awaitNextSchedule().action()
+        server.takeRequest(5, TimeUnit.SECONDS)
+        val second = scheduler.awaitNextSchedule()
+        assertEquals(15_000L, second.delayMillis)
+        second.action()
+
+        val secondRequest = server.takeRequest(5, TimeUnit.SECONDS)!!
+        assertEquals(VIEWER_ID, JSONObject(secondRequest.body.readUtf8()).getString("viewer_id"))
+    }
+
+    @Test
+    fun `schedules the next heartbeat using next_heartbeat_in from the response`() {
+        server.enqueue(heartbeatOkResponse(nextHeartbeatIn = 42))
+        val manager = buildManager()
+
+        manager.start(baseUrl(), "token-1")
+        scheduler.awaitNextSchedule().action()
+        server.takeRequest(5, TimeUnit.SECONDS)
+
+        assertEquals(42_000L, scheduler.awaitNextSchedule().delayMillis)
+    }
+
+    @Test
+    fun `on 401, refreshes via onTokenExpired and resumes with the new token`() {
+        server.enqueue(MockResponse().setResponseCode(401))
+        server.enqueue(heartbeatOkResponse())
+        var refreshCallCount = 0
+        val manager = buildManager(onTokenExpired = { callback ->
+            refreshCallCount++
+            callback("refreshed-token")
+        })
+
+        manager.start(baseUrl(), "token-1")
+        scheduler.awaitNextSchedule().action()
+        server.takeRequest(5, TimeUnit.SECONDS)
+        scheduler.awaitNextSchedule().action()
+
+        val secondRequest = server.takeRequest(5, TimeUnit.SECONDS)!!
+        assertEquals(1, refreshCallCount)
+        assertEquals("Bearer refreshed-token", secondRequest.getHeader("Authorization"))
+    }
+
+    @Test
+    fun `does not distinguish an expired token from a device-binding mismatch, both 401s refresh the same way`() {
+        server.enqueue(MockResponse().setResponseCode(401))
+        var refreshCallCount = 0
+        val manager = buildManager(onTokenExpired = { callback ->
+            refreshCallCount++
+            callback("refreshed-token")
+        })
+
+        manager.start(baseUrl(), "token-1")
+        scheduler.awaitNextSchedule().action()
+        server.takeRequest(5, TimeUnit.SECONDS)
+        scheduler.awaitNextSchedule()
+
+        assertEquals(1, refreshCallCount)
+    }
+
+    @Test
+    fun `keeps backing off with a growing delay instead of giving up when refresh keeps failing`() {
+        server.enqueue(MockResponse().setResponseCode(401))
+        server.enqueue(MockResponse().setResponseCode(401))
+        val manager = buildManager(onTokenExpired = { callback -> callback("") })
+
+        manager.start(baseUrl(), "token-1")
+        scheduler.awaitNextSchedule().action()
+        server.takeRequest(5, TimeUnit.SECONDS)
+        val afterFirstFailure = scheduler.awaitNextSchedule()
+        assertEquals(15_000L, afterFirstFailure.delayMillis)
+        afterFirstFailure.action()
+        server.takeRequest(5, TimeUnit.SECONDS)
+
+        val afterSecondFailure = scheduler.awaitNextSchedule()
+        assertTrue(
+            "expected a longer backoff on the second consecutive failure",
+            afterSecondFailure.delayMillis > afterFirstFailure.delayMillis
+        )
+    }
+
+    @Test
+    fun `respects Retry-After on a 429 instead of the default interval`() {
+        server.enqueue(MockResponse().setResponseCode(429).setHeader("Retry-After", "5"))
+        val manager = buildManager()
+
+        manager.start(baseUrl(), "token-1")
+        scheduler.awaitNextSchedule().action()
+        server.takeRequest(5, TimeUnit.SECONDS)
+
+        assertEquals(5_000L, scheduler.awaitNextSchedule().delayMillis)
+    }
+
+    @Test
+    fun `swallows a network error and keeps the loop alive on the fallback cadence`() {
+        val deadServer = MockWebServer()
+        deadServer.start()
+        val unreachableUrl = deadServer.url("/").toString().trimEnd('/')
+        deadServer.shutdown()
+        var observedError: Throwable? = null
+        val manager = buildManager(onError = { observedError = it })
+
+        manager.start(unreachableUrl, "token-1")
+        scheduler.awaitNextSchedule().action()
+
+        assertEquals(15_000L, scheduler.awaitNextSchedule().delayMillis)
+        assertTrue(observedError != null)
+    }
+
+    @Test
+    fun `start() is idempotent, calling it twice does not schedule a second loop`() {
+        server.enqueue(heartbeatOkResponse())
+        val manager = buildManager()
+
+        manager.start(baseUrl(), "token-1")
+        manager.start(baseUrl(), "token-2")
+        scheduler.awaitNextSchedule().action()
+
+        val request = server.takeRequest(5, TimeUnit.SECONDS)!!
+        assertEquals("Bearer token-1", request.getHeader("Authorization"))
+        scheduler.assertNothingScheduledWithin(200)
+    }
+
+    @Test
+    fun `stop() sends a leave beacon with the presence token and the same viewer id`() {
+        server.enqueue(MockResponse().setResponseCode(204))
+        val manager = buildManager()
+
+        manager.start(baseUrl(), "token-1")
+        manager.stop()
+
+        val request = server.takeRequest(5, TimeUnit.SECONDS)!!
+        assertEquals("/presence/v1/leave", request.path)
+        val body = JSONObject(request.body.readUtf8())
+        assertEquals("token-1", body.getString("presence_token"))
+        assertEquals(VIEWER_ID, body.getString("viewer_id"))
+    }
+
+    @Test
+    fun `stop() cancels the scheduled beat`() {
+        server.enqueue(MockResponse().setResponseCode(204))
+        val manager = buildManager()
+
+        manager.start(baseUrl(), "token-1")
+        manager.stop()
+
+        assertEquals(1, scheduler.cancelledCount.get())
+    }
+
+    @Test
+    fun `stop() is idempotent, a second call does not send another beacon`() {
+        server.enqueue(MockResponse().setResponseCode(204))
+        val manager = buildManager()
+
+        manager.start(baseUrl(), "token-1")
+        manager.stop()
+        manager.stop()
+
+        server.takeRequest(5, TimeUnit.SECONDS)
+        assertNull(server.takeRequest(200, TimeUnit.MILLISECONDS))
+    }
+
+    @Test
+    fun `stopped heartbeat loop does not schedule any further beats`() {
+        server.enqueue(MockResponse().setResponseCode(204)) // consumed by stop()'s leave beacon
+        val manager = buildManager()
+
+        manager.start(baseUrl(), "token-1")
+        val first = scheduler.awaitNextSchedule()
+        manager.stop()
+        val leaveRequest = server.takeRequest(5, TimeUnit.SECONDS)!!
+        assertEquals("/presence/v1/leave", leaveRequest.path)
+        first.action()
+
+        // Only the leave beacon above should ever have reached the server —
+        // an errant heartbeat from the stopped beat would show up as a second.
+        assertNull(server.takeRequest(300, TimeUnit.MILLISECONDS))
+        scheduler.assertNothingScheduledWithin(200)
+    }
+}

--- a/tpstreams-android-player/src/test/java/com/tpstreams/player/presence/PresenceViewerIdStoreTest.kt
+++ b/tpstreams-android-player/src/test/java/com/tpstreams/player/presence/PresenceViewerIdStoreTest.kt
@@ -1,0 +1,58 @@
+package com.tpstreams.player.presence
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+private val UUID_PATTERN = Regex(
+    "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    RegexOption.IGNORE_CASE
+)
+
+private class InMemoryKeyValueStore : PersistentKeyValueStore {
+    private val values = mutableMapOf<String, String>()
+
+    override fun getString(key: String): String? = values[key]
+
+    override fun putString(key: String, value: String) {
+        values[key] = value
+    }
+}
+
+class PresenceViewerIdStoreTest {
+
+    @Test
+    fun `generates a UUID-shaped id`() {
+        val id = PresenceViewerIdStore(InMemoryKeyValueStore()).getOrCreate()
+
+        assertTrue(UUID_PATTERN.matches(id))
+    }
+
+    @Test
+    fun `persists the generated id in the underlying store`() {
+        val store = InMemoryKeyValueStore()
+
+        val id = PresenceViewerIdStore(store).getOrCreate()
+
+        assertEquals(id, store.getString("viewer_id"))
+    }
+
+    @Test
+    fun `returns the same id on a later call against the same store, as across an app restart`() {
+        val store = InMemoryKeyValueStore()
+
+        val first = PresenceViewerIdStore(store).getOrCreate()
+        val second = PresenceViewerIdStore(store).getOrCreate()
+
+        assertEquals(first, second)
+    }
+
+    @Test
+    fun `returns different ids for independent stores`() {
+        val first = PresenceViewerIdStore(InMemoryKeyValueStore()).getOrCreate()
+        val second = PresenceViewerIdStore(InMemoryKeyValueStore()).getOrCreate()
+
+        assertNotEquals(first, second)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a presence heartbeat/leave client to the Android player SDK, matching the protocol and behavior already shipped for the web embed player and live-analytics service (`/presence/v1/heartbeat`, `/presence/v1/leave`).
- `PresenceHeartbeatManager` — starts/stops with playback (`onIsPlayingChanged`, `release()`), jittered first heartbeat, server-driven cadence via `next_heartbeat_in`, `Retry-After` handling on 429, capped backoff on repeated 401s, best-effort fire-and-forget leave call.
- `PresenceViewerIdStore` — SharedPreferences-backed persistent viewer/device ID, generated once and reused across sessions (same ID resent on every heartbeat for device-binding checks server-side).
- `PresenceScheduler` — Handler-based timer abstraction, injectable for tests.
- `TPStreamsPlayer.Listener.onPresenceTokenExpired(videoId, callback)` — new **optional, default no-op** listener method (matches the existing `onNetworkDiagnosticsStarted()` pattern) fired on a 401, so integrators can fetch a fresh token and resolve the callback. Presence is still rollout-gated to 3 orgs, so this is opt-in and won't affect existing integrators who don't implement it.
- `AssetInfo`/API layer: `viewer_id` is appended to the asset-info request when available, and the response's `live_stream.presence.{token,base_url}` is parsed into a new `PresenceConfig` and passed to the player.

## Test plan
- New unit tests: `PresenceViewerIdStoreTest`, `PresenceHeartbeatManagerTest` (MockWebServer-based, using a `RecordingPresenceScheduler` for deterministic timer control)
- Extended `ApiServiceTest` with viewer_id URL construction and presence-parsing cases
- Not yet build/runtime-verified in a full app since this is a library-only change; downstream verification happens via the Flutter/RN wrapper SDKs (see linked PRs) once this merges and releases

Related: testpress/iOSPlayerSDK#170, testpress/streams#2507, testpress/flutter-player-sdk#56, testpress/react-native-tpstreams#57, testpress/player.js#42