### PR TITLE
fix: position watermark within video content area instead of full player

### DIFF
--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/TPStreamsPlayerView.kt
@@ -790,15 +790,6 @@ class TPStreamsPlayerView @JvmOverloads constructor(
         watermarkControllers.clear()
     }
 
-    /**
-     * Returns the child index at which watermark containers should be inserted.
-     * Placed before the error overlay so that watermarks render below error/loading UI.
-     */
-    internal fun getWatermarkInsertIndex(): Int {
-        val index = errorOverlay?.let { indexOfChild(it) } ?: -1
-        return if (index >= 0) index else childCount
-    }
-
     private fun notifyWatermarkPlayerState() {
         val player = getPlayer() ?: return
         watermarkControllers.forEach {

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/WatermarkController.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/WatermarkController.kt
@@ -1,16 +1,21 @@
 package com.tpstreams.player
 
 import android.animation.ValueAnimator
+import android.util.Log
 import android.view.View
 import android.widget.FrameLayout
 import android.widget.TextView
 import androidx.media3.common.Player
+import androidx.media3.ui.AspectRatioFrameLayout
 
 @androidx.media3.common.util.UnstableApi
 internal class WatermarkController(private val parent: TPStreamsPlayerView) {
 
     private var container: FrameLayout? = null
     private var config: WatermarkConfig? = null
+
+    private val contentFrame: AspectRatioFrameLayout?
+        get() = parent.findViewById(androidx.media3.ui.R.id.exo_content_frame)
 
     private var currentIsPlaying = false
 
@@ -53,7 +58,7 @@ internal class WatermarkController(private val parent: TPStreamsPlayerView) {
     fun remove() {
         pingPongAnimator?.cancel()
         pingPongAnimator = null
-        container?.let { parent.removeView(it) }
+        container?.let { contentFrame?.removeView(it) }
         container = null
         config = null
     }
@@ -108,8 +113,13 @@ internal class WatermarkController(private val parent: TPStreamsPlayerView) {
 
     private fun addToParent() {
         val c = container ?: return
-        val insertIndex = parent.getWatermarkInsertIndex()
-        parent.addView(c, insertIndex)
+        val frame = contentFrame
+        if (frame == null) {
+            Log.w(TAG, "exo_content_frame not found — watermark will not be displayed. " +
+                "Ensure the player layout contains an AspectRatioFrameLayout with id exo_content_frame.")
+            return
+        }
+        frame.addView(c, frame.childCount)
     }
 
     // ── Positioning ──────────────────────────────────────────────────────
@@ -117,7 +127,8 @@ internal class WatermarkController(private val parent: TPStreamsPlayerView) {
     private fun reposition() {
         val c = container ?: return
         val cfg = config ?: return
-        if (parent.width == 0 || parent.height == 0) return
+        val frame = contentFrame ?: return
+        if (frame.width == 0 || frame.height == 0) return
         if (c.width == 0 || c.height == 0) return
 
         val animXy = getAnimationCurrentPosition()
@@ -137,8 +148,9 @@ internal class WatermarkController(private val parent: TPStreamsPlayerView) {
 
     private fun placeAt(xFrac: Float, yFrac: Float) {
         val c = container ?: return
-        val parentWidth = parent.width
-        val parentHeight = parent.height
+        val frame = contentFrame ?: return
+        val parentWidth = frame.width
+        val parentHeight = frame.height
         if (parentWidth == 0 || parentHeight == 0) return
 
         val viewWidth = c.width
@@ -196,6 +208,7 @@ internal class WatermarkController(private val parent: TPStreamsPlayerView) {
     // ── Helpers ──────────────────────────────────────────────────────────
 
     companion object {
+        private const val TAG = "WatermarkController"
         private const val DEFAULT_MARGIN_DP = 16
     }
 }

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/WatermarkController.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/WatermarkController.kt
@@ -158,15 +158,12 @@ internal class WatermarkController(private val parent: TPStreamsPlayerView) {
         if (viewWidth == 0 || viewHeight == 0) return
 
         val density = parent.context.resources.displayMetrics.density
-        val m = DEFAULT_MARGIN_DP * density
 
-        val minX = m
-        val maxX = (parentWidth - viewWidth - m).coerceAtLeast(m)
-        val minY = m
-        val maxY = (parentHeight - viewHeight - m).coerceAtLeast(m)
+        val maxX = (parentWidth - viewWidth).coerceAtLeast(0)
+        val maxY = (parentHeight - viewHeight).coerceAtLeast(0)
 
-        val x = minX + xFrac * (maxX - minX)
-        val y = minY + yFrac * (maxY - minY)
+        val x = xFrac * maxX
+        val y = yFrac * maxY
 
         c.pivotX = viewWidth * xFrac
         c.pivotY = viewHeight * yFrac
@@ -209,6 +206,5 @@ internal class WatermarkController(private val parent: TPStreamsPlayerView) {
 
     companion object {
         private const val TAG = "WatermarkController"
-        private const val DEFAULT_MARGIN_DP = 16
     }
 }

--- a/tpstreams-android-player/src/main/java/com/tpstreams/player/WatermarkController.kt
+++ b/tpstreams-android-player/src/main/java/com/tpstreams/player/WatermarkController.kt
@@ -13,9 +13,7 @@ internal class WatermarkController(private val parent: TPStreamsPlayerView) {
 
     private var container: FrameLayout? = null
     private var config: WatermarkConfig? = null
-
-    private val contentFrame: AspectRatioFrameLayout?
-        get() = parent.findViewById(androidx.media3.ui.R.id.exo_content_frame)
+    private var contentFrame: AspectRatioFrameLayout? = null
 
     private var currentIsPlaying = false
 
@@ -29,6 +27,7 @@ internal class WatermarkController(private val parent: TPStreamsPlayerView) {
         if (config == null) return
 
         this.config = config
+        contentFrame = parent.findViewById(androidx.media3.ui.R.id.exo_content_frame)
 
         val player = parent.getPlayer()
         if (player != null) {
@@ -61,6 +60,7 @@ internal class WatermarkController(private val parent: TPStreamsPlayerView) {
         container?.let { contentFrame?.removeView(it) }
         container = null
         config = null
+        contentFrame = null
     }
 
     fun onParentLayout() {


### PR DESCRIPTION


Watermarks were previously added as children of TPStreamsPlayerView (the full player FrameLayout), causing them to be positioned relative to the entire view — including letterbox/pillarbox black bars when the video aspect ratio differs from the player view.

Move watermark views into the AspectRatioFrameLayout (exo_content_frame) so they are constrained to the actual rendered video rectangle. This ensures watermarks never appear on the black bars regardless of video aspect ratio or resize mode.

Changes:
- WatermarkController: add contentFrame property referencing exo_content_frame; add/remove/reposition watermarks within it
- TPStreamsPlayerView: remove getWatermarkInsertIndex() (no longer needed since watermarks are now children of the content frame)